### PR TITLE
Serve React build and style update

### DIFF
--- a/backend/routes/questions.js
+++ b/backend/routes/questions.js
@@ -1,5 +1,5 @@
 // backend/routes/questions.js
-const express = require('express');
+import express from 'express';
 const router  = express.Router();
 
 const questions = [
@@ -13,4 +13,4 @@ router.get('/', (req, res) => {
   res.json({ questions });
 });
 
-module.exports = router;
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,22 @@
-// backend/server.js
-import app from './src/app.js';
+import express from 'express';
+import cors from 'cors';
+import path from 'path';
 import questionsRouter from './routes/questions.js';
 
-//mount the questions route under /api/questions
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// API routes
 app.use('/api/questions', questionsRouter);
+
+// Serve frontend build
+const __dirname = path.resolve();
+app.use(express.static(path.join(__dirname, 'frontend', 'build')));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'frontend', 'build', 'index.html'));
+});
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -114,21 +114,21 @@
   <div class="layer layer2 sticky-layer">
     <div class="verse">गा व्य-स्या त्म-सं सा रे क वी रे व प्र जा प ति: य था स् मै रो च ते वि ष्वं तथे दं प रि व र्त ते</div>
     <div class="translation">
-      In the self-world of poetry, the poet alone is the Prajāpati, the lord of creation.<br>
+      Amidst limitless imagination, the poet alone is Prajāpati, the lord of creation.<br>
       Just as it pleases him, so too does the world transform.
     </div>
   </div>
 
   <div class="layer layer3 sticky-layer">
     <div class="quote">
-      truth resides in the reconstruction of events without precedent<br/>
-      in a world where nothing repeats itself exactly; where sense<br/>
-      comes from the association of memory.
+      Two things, science and remembrance of things past, share in common a fact that truth resides in the reconstruction of events without precedent<br/>
+      in a world where nothing happens the same way twice; in this astonishing world where sense<br/>
+      comes from the association of memory and scientific certainty from the replication of experiment.
     </div>
     <div class="quote">
       to be a person, to act as one ought,<br/>
       to act according to the categorical imperative,<br/>
-      in other words, to be oneself cohesive through time (having said something thoughtless)<br/>
+      in other words, to be one self cohesive through time (having risked expressing something that approaches thoughtlessness)<br/>
       one may not want to identify a 'self' as unified in any 'person'
     </div>
   </div>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Noto+Serif+Devanagari&family=Noto+Sans+Tamil&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="%PUBLIC_URL%/style.css" />
   <style>
     html, body {
       margin: 0;

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -1,7 +1,8 @@
 body {
   margin: 0;
   padding: 0;
-  background-color: #000;
+  background: linear-gradient(to bottom, #0d0f25, #1a3b40 60%, #faebd7);
+  background-attachment: fixed;
   font-family: 'Orbitron', sans-serif;
   color: #00ffff;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- serve the built React frontend from Express
- convert questions route to ES modules
- use a gradient background in public style
- reference the CSS file from the base `index.html`

## Testing
- `npm start` *(backend server launches)*
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688ac771c9cc832589a26fc7ef1dab65