### PR TITLE
Add Tor DNS + onion uptime monitoring stack

### DIFF
--- a/tools/tor-watch/README.md
+++ b/tools/tor-watch/README.md
@@ -1,0 +1,40 @@
+# Tor DNS + Onion Uptime Monitor
+
+This stack gives you:
+
+1. A DNS resolver endpoint (`:53`) backed by Tor `DNSPort`.
+2. A SOCKS5 Tor proxy (`:9050`) for `.onion` access.
+3. A monitor service that checks onion URLs for uptime, captures redirects, and stores discovered `.onion` candidates + mirror-like signatures.
+
+## Quick start
+
+```bash
+cd tools/tor-watch
+docker compose up -d --build
+```
+
+## Configure monitored sites
+
+Edit `monitor/targets.txt` and add one onion URL per line:
+
+```text
+http://youronionv3addressxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.onion/
+```
+
+The monitor loops every 300 seconds by default (`MONITOR_INTERVAL_SECONDS`).
+
+## Data captured
+
+Monitor writes to SQLite at `monitor-data` volume (`/data/monitor.db`) with:
+
+- `checks`: success/failure status, status code, final URL, content signature.
+- `discovered_onions`: onion URLs detected in page HTML and links.
+
+Mirror detection is signature-based (normalized page text hash). This is a heuristic; tune for your threat model.
+
+## Notes and limitations
+
+- Tor DNS is not a full recursive resolver and some clients/features may expect behavior it does not provide.
+- Onion liveness checks should prefer HTTP GET through SOCKS (`socks5h`) rather than ICMP ping.
+- Auto-follow to “new locations” is intentionally passive here: it records redirects/discovered onions; it does not rewrite targets automatically.
+- For production you should add alerting (Prometheus/Grafana, Loki, or webhook notifications), rate limits, and authentication for any exposed dashboards.

--- a/tools/tor-watch/docker-compose.yml
+++ b/tools/tor-watch/docker-compose.yml
@@ -1,0 +1,56 @@
+version: "3.9"
+
+services:
+  tor:
+    image: osminogin/tor-simple:latest
+    container_name: tor-dns-tor
+    restart: unless-stopped
+    volumes:
+      - ./torrc:/etc/tor/torrc:ro
+      - tor-data:/var/lib/tor
+    ports:
+      - "9050:9050"      # SOCKS5 proxy for monitor and clients
+      - "5353:5353/udp"  # Tor DNSPort (query via dns service below)
+    networks:
+      - torwatch
+
+  dns:
+    image: andyshinn/dnsmasq:2.86
+    container_name: tor-dns-dnsmasq
+    restart: unless-stopped
+    depends_on:
+      - tor
+    command: ["-k", "--log-facility=-", "--no-resolv", "--server=tor#5353", "--cache-size=1000"]
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+    networks:
+      - torwatch
+
+  monitor:
+    build:
+      context: ./monitor
+    container_name: tor-dns-monitor
+    restart: unless-stopped
+    depends_on:
+      - tor
+    environment:
+      - TOR_SOCKS_HOST=tor
+      - TOR_SOCKS_PORT=9050
+      - MONITOR_INTERVAL_SECONDS=300
+      - MONITOR_TARGETS_FILE=/app/targets.txt
+      - MONITOR_DB_PATH=/data/monitor.db
+      - MONITOR_FOLLOW_REDIRECTS=true
+    volumes:
+      - ./monitor/targets.txt:/app/targets.txt:ro
+      - monitor-data:/data
+    networks:
+      - torwatch
+
+networks:
+  torwatch:
+    driver: bridge
+
+volumes:
+  tor-data:
+  monitor-data:

--- a/tools/tor-watch/monitor/Dockerfile
+++ b/tools/tor-watch/monitor/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY monitor.py ./
+COPY targets.txt ./
+
+CMD ["python", "monitor.py"]

--- a/tools/tor-watch/monitor/monitor.py
+++ b/tools/tor-watch/monitor/monitor.py
@@ -1,0 +1,183 @@
+import hashlib
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+ONION_RE = re.compile(r"[a-z2-7]{56}\.onion", re.IGNORECASE)
+
+
+@dataclass
+class Config:
+    socks_host: str = os.getenv("TOR_SOCKS_HOST", "tor")
+    socks_port: int = int(os.getenv("TOR_SOCKS_PORT", "9050"))
+    interval_s: int = int(os.getenv("MONITOR_INTERVAL_SECONDS", "300"))
+    targets_file: str = os.getenv("MONITOR_TARGETS_FILE", "/app/targets.txt")
+    db_path: str = os.getenv("MONITOR_DB_PATH", "/data/monitor.db")
+    follow_redirects: bool = os.getenv("MONITOR_FOLLOW_REDIRECTS", "true").lower() == "true"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_targets(path: str) -> list[str]:
+    targets: list[str] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            targets.append(line)
+    return targets
+
+
+def normalize_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    text = soup.get_text(" ", strip=True)
+    return re.sub(r"\s+", " ", text).lower()
+
+
+def content_signature(html: str) -> str:
+    normalized = normalize_text(html)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def discover_onion_candidates(base_url: str, html: str) -> set[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    found: set[str] = set(ONION_RE.findall(html))
+
+    for a in soup.find_all("a", href=True):
+        full = urljoin(base_url, a["href"])
+        host = (urlparse(full).hostname or "").lower()
+        if ONION_RE.fullmatch(host):
+            found.add(host)
+
+    return {f"http://{host}/" for host in found}
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS checks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            checked_at TEXT NOT NULL,
+            target_url TEXT NOT NULL,
+            final_url TEXT,
+            status_code INTEGER,
+            ok INTEGER NOT NULL,
+            error TEXT,
+            content_sig TEXT,
+            title TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS discovered_onions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            discovered_at TEXT NOT NULL,
+            source_url TEXT NOT NULL,
+            discovered_url TEXT NOT NULL,
+            UNIQUE(source_url, discovered_url)
+        )
+        """
+    )
+    conn.commit()
+
+
+def save_discoveries(conn: sqlite3.Connection, source_url: str, discoveries: Iterable[str]) -> None:
+    for url in discoveries:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO discovered_onions (discovered_at, source_url, discovered_url)
+            VALUES (?, ?, ?)
+            """,
+            (utc_now(), source_url, url),
+        )
+    conn.commit()
+
+
+def recently_seen_signature(conn: sqlite3.Connection, signature: str, current_target: str) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT target_url
+        FROM checks
+        WHERE content_sig = ? AND target_url <> ?
+        ORDER BY checked_at DESC
+        LIMIT 5
+        """,
+        (signature, current_target),
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def run() -> None:
+    cfg = Config()
+    session = requests.Session()
+    session.proxies = {
+        "http": f"socks5h://{cfg.socks_host}:{cfg.socks_port}",
+        "https": f"socks5h://{cfg.socks_host}:{cfg.socks_port}",
+    }
+    session.headers.update({"User-Agent": "tor-uptime-monitor/0.1"})
+
+    conn = sqlite3.connect(cfg.db_path)
+    init_db(conn)
+
+    while True:
+        targets = load_targets(cfg.targets_file)
+        for target in targets:
+            checked_at = utc_now()
+            try:
+                response = session.get(target, timeout=45, allow_redirects=cfg.follow_redirects)
+                html = response.text or ""
+                sig = content_signature(html) if html else None
+                title = BeautifulSoup(html, "html.parser").title
+                title_text = title.get_text(strip=True) if title else None
+                final_url = response.url
+
+                conn.execute(
+                    """
+                    INSERT INTO checks (checked_at, target_url, final_url, status_code, ok, error, content_sig, title)
+                    VALUES (?, ?, ?, ?, 1, NULL, ?, ?)
+                    """,
+                    (checked_at, target, final_url, response.status_code, sig, title_text),
+                )
+                conn.commit()
+
+                discoveries = discover_onion_candidates(final_url, html)
+                if discoveries:
+                    save_discoveries(conn, target, discoveries)
+
+                if sig:
+                    mirrors = recently_seen_signature(conn, sig, target)
+                    if mirrors:
+                        print(f"[{checked_at}] mirror-like content for {target}: {mirrors}")
+
+                if final_url != target:
+                    print(f"[{checked_at}] redirect {target} -> {final_url}")
+
+                print(f"[{checked_at}] ok {target} ({response.status_code})")
+            except Exception as exc:  # noqa: BLE001
+                conn.execute(
+                    """
+                    INSERT INTO checks (checked_at, target_url, final_url, status_code, ok, error, content_sig, title)
+                    VALUES (?, ?, NULL, NULL, 0, ?, NULL, NULL)
+                    """,
+                    (checked_at, target, str(exc)),
+                )
+                conn.commit()
+                print(f"[{checked_at}] fail {target}: {exc}")
+
+        time.sleep(cfg.interval_s)
+
+
+if __name__ == "__main__":
+    run()

--- a/tools/tor-watch/monitor/requirements.txt
+++ b/tools/tor-watch/monitor/requirements.txt
@@ -1,0 +1,2 @@
+requests[socks]==2.32.3
+beautifulsoup4==4.12.3

--- a/tools/tor-watch/monitor/targets.txt
+++ b/tools/tor-watch/monitor/targets.txt
@@ -1,0 +1,3 @@
+# one onion URL per line
+# example:
+# http://exampleonionaddress1234567890abcdef1234567890abcdef1234.onion/

--- a/tools/tor-watch/torrc
+++ b/tools/tor-watch/torrc
@@ -1,0 +1,7 @@
+SocksPort 0.0.0.0:9050
+DNSPort 0.0.0.0:5353
+AutomapHostsOnResolve 1
+VirtualAddrNetworkIPv4 172.16.0.0/12
+ClientUseIPv6 1
+ClientOnly 1
+SafeLogging 1


### PR DESCRIPTION
### Motivation

- Provide a self-contained deployable stack that exposes Tor `SocksPort` and `DNSPort` and a local DNS front-end so clients can resolve and access `.onion` sites. 
- Add an uptime monitoring worker that checks onion URLs over Tor, records redirects/final locations, and helps discover mirrors or new onion locations. 
- Offer an easy-to-run Docker Compose layout and documentation so the tooling can be run locally or in a containerized environment.

### Description

- Add `tools/tor-watch/docker-compose.yml` which wires together a Tor container (SOCKS + DNSPort), a `dnsmasq` DNS front-end on port `53`, and a monitor worker service. 
- Add `tools/tor-watch/torrc` with a client-only Tor configuration enabling `SocksPort`, `DNSPort`, host automapping, and safe logging for this use case. 
- Implement the monitor in `tools/tor-watch/monitor/monitor.py` and supporting files (`Dockerfile`, `requirements.txt`, `targets.txt`) which perform HTTP checks via `socks5h`, persist results to SQLite, capture redirects/final URLs, discover onion candidates in page HTML/links, and compute normalized-text content signatures to flag mirror-like pages. 
- Include `tools/tor-watch/README.md` with quick-start instructions, data schema notes, and operational caveats (passive discovery behavior and mirror-detection heuristic guidance). 

### Testing

- Ran `python3 -m py_compile tools/tor-watch/monitor/monitor.py` which succeeded. 
- Attempted `docker compose -f tools/tor-watch/docker-compose.yml config` but the Docker CLI was unavailable in this environment (`docker: command not found`). 
- No additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998976629c4832589427f27fb07a9fd)