### PR TITLE
feat(gate): update config for production gate.env

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,18 +1,37 @@
-"""Application configuration via environment variables."""
+"""Application configuration via environment variables.
+
+All values are read from env vars at startup. Defaults are empty/generic
+placeholders — production values live in gate.env (not committed).
+"""
 
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    # Database
-    database_url: str = "postgresql://a4m_gate_app@/a4m_gate?host=/var/run/postgresql-gate&port=5433"
+    # Database — fallback chain: VPN → domain → localhost
+    database_url: str = ""
+    database_url_primary: str = ""
+    database_url_secondary: str = ""
+    database_url_local: str = ""
 
-    # Age encryption
+    # Age encryption (X25519 public key)
     age_recipient: str = ""
 
     # Secrets
-    hmac_secret: str = ""       # HMAC-SHA256 key for ZK email lookups
+    hmac_secret: str = ""       # SESSION_HMAC_SECRET — HMAC-SHA256 key
     session_secret: str = ""    # Fernet key for encrypting session cookies
+
+    # Bind address
+    bind_addr: str = "127.0.0.1:8787"
+
+    # Inter-service auth
+    gate_api_key: str = ""
+
+    # Fresh API URLs — clearnet Deno server (fallback chain)
+    fresh_api_primary: str = ""
+    fresh_api_secondary: str = ""
+    fresh_api_local: str = ""
+    fresh_api_domain: str = ""
 
     # Rate limiting
     rate_limit_window: int = 60     # seconds
@@ -28,8 +47,7 @@ class Settings(BaseSettings):
     lotto_drand_url_template: str = "https://api.drand.sh/public/{round}"
     lotto_default_drand_round_target: int = 0
     lotto_operator_token: str = ""
-    # Base64-encoded raw Ed25519 private key bytes (32 bytes).
-    lotto_operator_signing_key_b64: str = ""
+    lotto_operator_signing_key_b64: str = ""  # Base64 raw Ed25519 (32 bytes)
 
     model_config = {"env_prefix": "", "case_sensitive": False}
 


### PR DESCRIPTION
## Summary
- Updates `app/config.py` with production field structure matching `gate.env`
- Database URL fallback chain (VPN → domain → localhost)
- Age recipient, bind address, gate API key, Fresh API URL fields
- All defaults empty — production values sourced from gate.env at runtime

@coderabbitai review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration & Infrastructure**
  * Added multi-environment database configuration with separate primary, secondary, and local endpoints
  * Introduced API key and session timeout configuration options
  * Enhanced network binding and deployment configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->