### PR TITLE
Add Distortion Lab demo page with HTML/CSS/JS assets

### DIFF
--- a/public/aformulationiontruth.html
+++ b/public/aformulationiontruth.html
@@ -17,6 +17,7 @@
 
     <section class="panel input-panel">
       <h2>Your Claim</h2>
+      <label for="claimInput">Your Claim</label>
       <textarea id="claimInput" rows="4" placeholder="Type a statement to lovingly ruin..."></textarea>
 
       <div class="slider-grid">

--- a/public/aformulationiontruth.html
+++ b/public/aformulationiontruth.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>aformulationiontruth.com — The Anti-Truth Engine</title>
+  <meta name="description" content="Confidently incorrect since page load." />
+  <link rel="stylesheet" href="/css/distortion-lab.css" />
+</head>
+<body>
+  <main class="site-shell">
+    <header class="hero">
+      <p class="kicker">aformulationiontruth.com</p>
+      <h1>A Malformation of Truth</h1>
+      <p class="subtitle">Confidently incorrect since page load.</p>
+    </header>
+
+    <section class="panel input-panel">
+      <h2>Your Claim</h2>
+      <textarea id="claimInput" rows="4" placeholder="Type a statement to lovingly ruin..."></textarea>
+
+      <div class="slider-grid">
+        <label>
+          Certainty
+          <input id="certainty" type="range" min="0" max="100" value="75" />
+          <span id="certaintyValue">75</span>
+        </label>
+
+        <label>
+          Vagueness
+          <input id="vagueness" type="range" min="0" max="100" value="35" />
+          <span id="vaguenessValue">35</span>
+        </label>
+
+        <label>
+          Emotional Bias
+          <input id="bias" type="range" min="0" max="100" value="55" />
+          <span id="biasValue">55</span>
+        </label>
+
+        <label>
+          Conspiracy Level
+          <input id="conspiracy" type="range" min="0" max="100" value="20" />
+          <span id="conspiracyValue">20</span>
+        </label>
+      </div>
+
+      <div class="action-row">
+        <button id="distortBtn">Distort Claim</button>
+        <button id="contradictBtn" class="secondary">Contradict</button>
+      </div>
+    </section>
+
+    <section class="panel output-panel">
+      <h2>Output</h2>
+      <p class="meter">Confidence Meter: <strong id="confidenceMeter">99%</strong></p>
+      <blockquote id="result">Your malformed truth will appear here.</blockquote>
+      <p class="source">Source: <span id="sourceText">Pending peer pressure.</span></p>
+    </section>
+
+    <section class="panel presets-panel">
+      <h2>Bias Presets</h2>
+      <div class="chips" id="presetChips">
+        <button data-preset="doomer">Doomer</button>
+        <button data-preset="corporate">Corporate Optimist</button>
+        <button data-preset="uncle">Conspiracy Uncle</button>
+        <button data-preset="guru">Motivational Guru</button>
+      </div>
+    </section>
+  </main>
+
+  <script src="/js/distortion-lab.js" defer></script>
+</body>
+</html>

--- a/public/css/distortion-lab.css
+++ b/public/css/distortion-lab.css
@@ -1,0 +1,125 @@
+:root {
+  color-scheme: dark;
+  --bg: #0d0d13;
+  --panel: #171723;
+  --line: #2e2e46;
+  --text: #f3f4ff;
+  --muted: #a4a6c3;
+  --accent: #ff3ef7;
+  --accent-2: #4cf2ff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  background: radial-gradient(circle at 20% 0%, #1b1b31 0%, var(--bg) 55%);
+  color: var(--text);
+}
+
+.site-shell {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 2.5rem 1rem 4rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.hero h1 {
+  margin: 0.25rem 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.kicker {
+  color: var(--accent-2);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.subtitle { color: var(--muted); }
+
+.panel {
+  background: linear-gradient(145deg, #1a1a2b, var(--panel));
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+h2 { margin-top: 0; }
+
+textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: #0f0f18;
+  color: var(--text);
+  padding: 0.8rem;
+  resize: vertical;
+}
+
+.slider-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+input[type="range"] { width: 100%; }
+
+.action-row {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+button {
+  border: 0;
+  background: var(--accent);
+  color: #110b14;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: transparent;
+  color: var(--accent-2);
+  border: 1px solid var(--accent-2);
+}
+
+blockquote {
+  margin: 0;
+  padding: 0.8rem;
+  border-left: 3px solid var(--accent);
+  background: #131320;
+  border-radius: 8px;
+  min-height: 3rem;
+}
+
+.meter,
+.source {
+  color: var(--muted);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chips button {
+  background: #26263e;
+  color: var(--text);
+  border: 1px solid #3c3c61;
+}

--- a/public/js/distortion-lab.js
+++ b/public/js/distortion-lab.js
@@ -38,8 +38,9 @@ function mirrorClaim(text) {
   const vagueAddon = vagueness > 60 ? 'in ways too complex to explain plainly' : 'in mostly observable ways';
   const biasAddon = bias > 60 ? pick(emotions) : '';
   const conspiracyAddon = conspiracy > 55 ? ` ${pick(conspiracies)}` : '';
+  const confidenceValue = Math.min(100, Math.max(0, Math.max(85, certainty + 18)));
 
-  confidenceMeter.textContent = `${Math.max(85, certainty + 18)}%`;
+  confidenceMeter.textContent = `${confidenceValue}%`;
   sourceText.textContent = pick(sources);
 
   return `${prefix} ${pick(hedges)} that "${text.trim()}" is true ${vagueAddon}${conspiracyAddon} ${biasAddon}`.replace(/\s+/g, ' ').trim();

--- a/public/js/distortion-lab.js
+++ b/public/js/distortion-lab.js
@@ -1,0 +1,87 @@
+const claimInput = document.getElementById('claimInput');
+const result = document.getElementById('result');
+const sourceText = document.getElementById('sourceText');
+const confidenceMeter = document.getElementById('confidenceMeter');
+
+const sliders = {
+  certainty: document.getElementById('certainty'),
+  vagueness: document.getElementById('vagueness'),
+  bias: document.getElementById('bias'),
+  conspiracy: document.getElementById('conspiracy'),
+};
+
+const sliderValues = {
+  certainty: document.getElementById('certaintyValue'),
+  vagueness: document.getElementById('vaguenessValue'),
+  bias: document.getElementById('biasValue'),
+  conspiracy: document.getElementById('conspiracyValue'),
+};
+
+const hedges = ['many people are saying', 'sources close to the situation confirm', 'it is universally known', 'serious thinkers agree'];
+const emotions = ['which should outrage everyone', 'and this is honestly inspiring', 'which proves how broken everything is', 'and that is deeply heroic'];
+const conspiracies = ['behind closed curtains', 'within a classified spreadsheet', 'inside a private algorithmic cabal', 'through an invisible committee'];
+const sources = ['fortune cookie archives', 'parking lot ethnography', 'group chat testimony', 'predictive dream logs'];
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function mirrorClaim(text) {
+  if (!text.trim()) return 'Reality is pending additional rumors.';
+
+  const certainty = Number(sliders.certainty.value);
+  const vagueness = Number(sliders.vagueness.value);
+  const bias = Number(sliders.bias.value);
+  const conspiracy = Number(sliders.conspiracy.value);
+
+  const prefix = certainty > 65 ? 'Undeniably,' : certainty > 35 ? 'Allegedly,' : 'Possibly,';
+  const vagueAddon = vagueness > 60 ? 'in ways too complex to explain plainly' : 'in mostly observable ways';
+  const biasAddon = bias > 60 ? pick(emotions) : '';
+  const conspiracyAddon = conspiracy > 55 ? ` ${pick(conspiracies)}` : '';
+
+  confidenceMeter.textContent = `${Math.max(85, certainty + 18)}%`;
+  sourceText.textContent = pick(sources);
+
+  return `${prefix} ${pick(hedges)} that "${text.trim()}" is true ${vagueAddon}${conspiracyAddon} ${biasAddon}`.replace(/\s+/g, ' ').trim();
+}
+
+function contradictClaim(text) {
+  const base = text.trim() || 'this statement';
+  sourceText.textContent = pick(sources);
+  confidenceMeter.textContent = '99%';
+  return `Experts now confirm the precise opposite of "${base}", with no further questions accepted.`;
+}
+
+Object.entries(sliders).forEach(([key, el]) => {
+  el.addEventListener('input', () => {
+    sliderValues[key].textContent = el.value;
+  });
+});
+
+document.getElementById('distortBtn').addEventListener('click', () => {
+  result.textContent = mirrorClaim(claimInput.value);
+});
+
+document.getElementById('contradictBtn').addEventListener('click', () => {
+  result.textContent = contradictClaim(claimInput.value);
+});
+
+document.getElementById('presetChips').addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) return;
+
+  const presets = {
+    doomer: { certainty: 70, vagueness: 45, bias: 90, conspiracy: 50 },
+    corporate: { certainty: 96, vagueness: 78, bias: 40, conspiracy: 10 },
+    uncle: { certainty: 88, vagueness: 52, bias: 76, conspiracy: 95 },
+    guru: { certainty: 99, vagueness: 65, bias: 85, conspiracy: 15 },
+  };
+
+  const preset = presets[target.dataset.preset];
+  if (!preset) return;
+
+  for (const [key, val] of Object.entries(preset)) {
+    sliders[key].value = val;
+    sliderValues[key].textContent = val;
+  }
+});

--- a/tests/unit/eslint-config.test.ts
+++ b/tests/unit/eslint-config.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Tests for .eslintrc.js configuration
+ *
+ * Validates the ESLint configuration structure, rule settings, and overrides
+ * introduced in this PR to enforce code quality standards.
+ *
+ * Note: .eslintrc.js uses CommonJS (module.exports) syntax. Because package.json
+ * has "type": "module", we use Module._compile to load it as CJS explicitly.
+ */
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import Module from 'module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Load a CommonJS config file in an ESM (type:module) package context.
+ * This is needed because package.json has "type":"module", which causes
+ * Node to treat .js files as ESM. The .eslintrc.js file uses module.exports,
+ * so we compile it as CJS manually.
+ */
+function loadCJSFile(relativePath: string): Record<string, unknown> {
+  const filepath = resolve(__dirname, relativePath);
+  const content = readFileSync(filepath, 'utf-8');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const m = new (Module as any)(filepath);
+  m.filename = filepath;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  m.paths = (Module as any)._nodeModulePaths(dirname(filepath));
+  m._compile(content, filepath);
+  return m.exports as Record<string, unknown>;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let eslintConfig: any;
+
+beforeAll(() => {
+  // Path from tests/unit/ up to project root where .eslintrc.js lives
+  eslintConfig = loadCJSFile('../../.eslintrc.js');
+});
+
+describe('.eslintrc.js configuration', () => {
+  describe('module export', () => {
+    it('exports a non-null object', () => {
+      expect(eslintConfig).toBeDefined();
+      expect(typeof eslintConfig).toBe('object');
+      expect(eslintConfig).not.toBeNull();
+    });
+
+    it('contains all top-level configuration keys', () => {
+      expect(eslintConfig).toHaveProperty('env');
+      expect(eslintConfig).toHaveProperty('extends');
+      expect(eslintConfig).toHaveProperty('parserOptions');
+      expect(eslintConfig).toHaveProperty('rules');
+      expect(eslintConfig).toHaveProperty('overrides');
+      expect(eslintConfig).toHaveProperty('ignorePatterns');
+    });
+  });
+
+  describe('env', () => {
+    it('enables browser environment', () => {
+      expect(eslintConfig.env.browser).toBe(true);
+    });
+
+    it('enables ES2021 environment', () => {
+      expect(eslintConfig.env.es2021).toBe(true);
+    });
+
+    it('enables Node.js environment', () => {
+      expect(eslintConfig.env.node).toBe(true);
+    });
+  });
+
+  describe('extends', () => {
+    it('is an array', () => {
+      expect(Array.isArray(eslintConfig.extends)).toBe(true);
+    });
+
+    it('includes eslint:recommended', () => {
+      expect(eslintConfig.extends).toContain('eslint:recommended');
+    });
+  });
+
+  describe('parserOptions', () => {
+    it('sets ecmaVersion to latest', () => {
+      expect(eslintConfig.parserOptions.ecmaVersion).toBe('latest');
+    });
+
+    it('sets sourceType to module', () => {
+      expect(eslintConfig.parserOptions.sourceType).toBe('module');
+    });
+  });
+
+  describe('rules', () => {
+    describe('no-irregular-whitespace', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['no-irregular-whitespace'];
+        expect(Array.isArray(rule)).toBe(true);
+        expect(rule[0]).toBe('error');
+      });
+
+      it('does not skip strings', () => {
+        const options = eslintConfig.rules['no-irregular-whitespace'][1];
+        expect(options.skipStrings).toBe(false);
+      });
+
+      it('does not skip comments', () => {
+        const options = eslintConfig.rules['no-irregular-whitespace'][1];
+        expect(options.skipComments).toBe(false);
+      });
+
+      it('does not skip regular expressions', () => {
+        const options = eslintConfig.rules['no-irregular-whitespace'][1];
+        expect(options.skipRegExps).toBe(false);
+      });
+
+      it('does not skip template literals', () => {
+        const options = eslintConfig.rules['no-irregular-whitespace'][1];
+        expect(options.skipTemplates).toBe(false);
+      });
+    });
+
+    describe('quotes', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['quotes'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('enforces single quotes', () => {
+        const rule = eslintConfig.rules['quotes'];
+        expect(rule[1]).toBe('single');
+      });
+
+      it('allows escape to avoid quote conflicts', () => {
+        const options = eslintConfig.rules['quotes'][2];
+        expect(options.avoidEscape).toBe(true);
+      });
+
+      it('allows template literals', () => {
+        const options = eslintConfig.rules['quotes'][2];
+        expect(options.allowTemplateLiterals).toBe(true);
+      });
+    });
+
+    describe('no-unused-vars', () => {
+      it('is set to warn level', () => {
+        const rule = eslintConfig.rules['no-unused-vars'];
+        expect(rule[0]).toBe('warn');
+      });
+
+      it('checks arguments after used position', () => {
+        const options = eslintConfig.rules['no-unused-vars'][1];
+        expect(options.args).toBe('after-used');
+      });
+
+      it('ignores rest siblings', () => {
+        const options = eslintConfig.rules['no-unused-vars'][1];
+        expect(options.ignoreRestSiblings).toBe(true);
+      });
+
+      it('ignores args prefixed with underscore', () => {
+        const options = eslintConfig.rules['no-unused-vars'][1];
+        expect(options.argsIgnorePattern).toBe('^_');
+      });
+    });
+
+    describe('semi', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['semi'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('always requires semicolons', () => {
+        const rule = eslintConfig.rules['semi'];
+        expect(rule[1]).toBe('always');
+      });
+    });
+
+    describe('comma-dangle', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['comma-dangle'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('never allows trailing commas', () => {
+        const rule = eslintConfig.rules['comma-dangle'];
+        expect(rule[1]).toBe('never');
+      });
+    });
+
+    describe('no-trailing-spaces', () => {
+      it('is set to error', () => {
+        expect(eslintConfig.rules['no-trailing-spaces']).toBe('error');
+      });
+    });
+
+    describe('eol-last', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['eol-last'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('always requires newline at end of file', () => {
+        const rule = eslintConfig.rules['eol-last'];
+        expect(rule[1]).toBe('always');
+      });
+    });
+
+    describe('indent', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['indent'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('enforces 2-space indentation', () => {
+        const rule = eslintConfig.rules['indent'];
+        expect(rule[1]).toBe(2);
+      });
+
+      it('indents switch cases by 1 level', () => {
+        const options = eslintConfig.rules['indent'][2];
+        expect(options.SwitchCase).toBe(1);
+      });
+    });
+
+    describe('object-curly-spacing', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['object-curly-spacing'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('always requires spaces inside braces', () => {
+        const rule = eslintConfig.rules['object-curly-spacing'];
+        expect(rule[1]).toBe('always');
+      });
+    });
+
+    describe('array-bracket-spacing', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['array-bracket-spacing'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('never allows spaces inside brackets', () => {
+        const rule = eslintConfig.rules['array-bracket-spacing'];
+        expect(rule[1]).toBe('never');
+      });
+    });
+
+    describe('space-before-blocks', () => {
+      it('is set to error', () => {
+        expect(eslintConfig.rules['space-before-blocks']).toBe('error');
+      });
+    });
+
+    describe('keyword-spacing', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['keyword-spacing'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('requires space before keywords', () => {
+        const options = eslintConfig.rules['keyword-spacing'][1];
+        expect(options.before).toBe(true);
+      });
+
+      it('requires space after keywords', () => {
+        const options = eslintConfig.rules['keyword-spacing'][1];
+        expect(options.after).toBe(true);
+      });
+    });
+
+    describe('space-infix-ops', () => {
+      it('is set to error', () => {
+        expect(eslintConfig.rules['space-infix-ops']).toBe('error');
+      });
+    });
+
+    describe('arrow-spacing', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['arrow-spacing'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('requires space before arrow', () => {
+        const options = eslintConfig.rules['arrow-spacing'][1];
+        expect(options.before).toBe(true);
+      });
+
+      it('requires space after arrow', () => {
+        const options = eslintConfig.rules['arrow-spacing'][1];
+        expect(options.after).toBe(true);
+      });
+    });
+
+    describe('no-multiple-empty-lines', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['no-multiple-empty-lines'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('allows at most 2 consecutive empty lines', () => {
+        const options = eslintConfig.rules['no-multiple-empty-lines'][1];
+        expect(options.max).toBe(2);
+      });
+
+      it('allows 0 empty lines at end of file', () => {
+        const options = eslintConfig.rules['no-multiple-empty-lines'][1];
+        expect(options.maxEOF).toBe(0);
+      });
+    });
+
+    describe('no-misleading-character-class', () => {
+      it('is set to error', () => {
+        expect(eslintConfig.rules['no-misleading-character-class']).toBe('error');
+      });
+    });
+
+    describe('unicode-bom', () => {
+      it('is set to error level', () => {
+        const rule = eslintConfig.rules['unicode-bom'];
+        expect(rule[0]).toBe('error');
+      });
+
+      it('never allows BOM characters', () => {
+        const rule = eslintConfig.rules['unicode-bom'];
+        expect(rule[1]).toBe('never');
+      });
+    });
+
+    describe('no-console (environment-dependent)', () => {
+      it('is off in non-production environments', () => {
+        // In the test environment NODE_ENV is not 'production', so the rule is 'off'
+        // The config evaluates: process.env.NODE_ENV === 'production' ? 'warn' : 'off'
+        expect(eslintConfig.rules['no-console']).toBe('off');
+      });
+    });
+
+    describe('no-debugger (environment-dependent)', () => {
+      it('is off in non-production environments', () => {
+        // In the test environment NODE_ENV is not 'production', so the rule is 'off'
+        // The config evaluates: process.env.NODE_ENV === 'production' ? 'error' : 'off'
+        expect(eslintConfig.rules['no-debugger']).toBe('off');
+      });
+    });
+  });
+
+  describe('overrides', () => {
+    it('is an array', () => {
+      expect(Array.isArray(eslintConfig.overrides)).toBe(true);
+    });
+
+    it('contains at least one override', () => {
+      expect(eslintConfig.overrides.length).toBeGreaterThanOrEqual(1);
+    });
+
+    describe('TypeScript override', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let tsOverride: any;
+
+      beforeAll(() => {
+        tsOverride = eslintConfig.overrides.find(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (o: any) => Array.isArray(o.files) && o.files.includes('*.ts')
+        );
+      });
+
+      it('exists for *.ts and *.tsx files', () => {
+        expect(tsOverride).toBeDefined();
+        expect(tsOverride.files).toContain('*.ts');
+        expect(tsOverride.files).toContain('*.tsx');
+      });
+
+      it('uses @typescript-eslint/parser', () => {
+        expect(tsOverride.parser).toBe('@typescript-eslint/parser');
+      });
+
+      it('extends @typescript-eslint/recommended', () => {
+        expect(tsOverride.extends).toContain('plugin:@typescript-eslint/recommended');
+      });
+
+      it('sets @typescript-eslint/no-explicit-any to warn', () => {
+        expect(tsOverride.rules['@typescript-eslint/no-explicit-any']).toBe('warn');
+      });
+
+      it('turns off explicit-module-boundary-types', () => {
+        expect(tsOverride.rules['@typescript-eslint/explicit-module-boundary-types']).toBe('off');
+      });
+    });
+  });
+
+  describe('ignorePatterns', () => {
+    it('is an array', () => {
+      expect(Array.isArray(eslintConfig.ignorePatterns)).toBe(true);
+    });
+
+    it('ignores node_modules/', () => {
+      expect(eslintConfig.ignorePatterns).toContain('node_modules/');
+    });
+
+    it('ignores dist/', () => {
+      expect(eslintConfig.ignorePatterns).toContain('dist/');
+    });
+
+    it('ignores build/', () => {
+      expect(eslintConfig.ignorePatterns).toContain('build/');
+    });
+
+    it('ignores minified JS files', () => {
+      expect(eslintConfig.ignorePatterns).toContain('*.min.js');
+    });
+
+    it('ignores coverage directory', () => {
+      expect(eslintConfig.ignorePatterns).toContain('coverage/');
+    });
+
+    it('ignores .git directory', () => {
+      expect(eslintConfig.ignorePatterns).toContain('.git/');
+    });
+  });
+
+  describe('rule severity consistency', () => {
+    it('all formatting rules use error level not numeric 2', () => {
+      const errorRules = [
+        'no-irregular-whitespace',
+        'semi',
+        'comma-dangle',
+        'no-trailing-spaces',
+        'eol-last',
+        'indent',
+        'object-curly-spacing',
+        'array-bracket-spacing',
+        'space-before-blocks',
+        'space-infix-ops',
+        'no-misleading-character-class',
+        'keyword-spacing',
+        'arrow-spacing',
+        'no-multiple-empty-lines',
+        'unicode-bom',
+      ];
+
+      for (const ruleName of errorRules) {
+        const rule = eslintConfig.rules[ruleName];
+        const severity = Array.isArray(rule) ? rule[0] : rule;
+        expect(severity).toBe('error');
+      }
+    });
+
+    it('no-unused-vars uses warn severity not numeric 1', () => {
+      const rule = eslintConfig.rules['no-unused-vars'];
+      const severity = Array.isArray(rule) ? rule[0] : rule;
+      expect(severity).toBe('warn');
+    });
+  });
+
+  describe('config consistency and design intent', () => {
+    it('indent and object-curly-spacing are compatible (2-space indent with spaced braces)', () => {
+      expect(eslintConfig.rules['indent'][1]).toBe(2);
+      expect(eslintConfig.rules['object-curly-spacing'][1]).toBe('always');
+    });
+
+    it('no-trailing-spaces and eol-last together eliminate file whitespace issues', () => {
+      expect(eslintConfig.rules['no-trailing-spaces']).toBe('error');
+      expect(eslintConfig.rules['eol-last'][1]).toBe('always');
+    });
+
+    it('keyword-spacing and space-before-blocks ensure consistent spacing around blocks', () => {
+      expect(eslintConfig.rules['keyword-spacing'][1].before).toBe(true);
+      expect(eslintConfig.rules['keyword-spacing'][1].after).toBe(true);
+      expect(eslintConfig.rules['space-before-blocks']).toBe('error');
+    });
+
+    it('no-irregular-whitespace is configured strictly with all skip options disabled', () => {
+      const opts = eslintConfig.rules['no-irregular-whitespace'][1];
+      expect(opts.skipStrings).toBe(false);
+      expect(opts.skipComments).toBe(false);
+      expect(opts.skipRegExps).toBe(false);
+      expect(opts.skipTemplates).toBe(false);
+    });
+
+    it('quotes rule allows template literals to support multi-line strings', () => {
+      expect(eslintConfig.rules['quotes'][1]).toBe('single');
+      expect(eslintConfig.rules['quotes'][2].allowTemplateLiterals).toBe(true);
+    });
+
+    it('comma-dangle never and eol-last always prevent trailing comma + no-newline issues', () => {
+      expect(eslintConfig.rules['comma-dangle'][1]).toBe('never');
+      expect(eslintConfig.rules['eol-last'][1]).toBe('always');
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a small interactive demo page that playfully transforms user statements into exaggerated/misleading output for exploration and UI testing.
- Expose tunable controls for certainty, vagueness, emotional bias, and conspiracy to prototype bias-presets and output formatting.

### Description

- Add `public/aformulationiontruth.html` which provides the page structure including a textarea input, four sliders, action buttons, an output blockquote, a confidence meter, and preset chips. 
- Add `public/css/distortion-lab.css` which defines a dark-themed layout, responsive grid for sliders, styled buttons, blocks, and CSS variables for theming. 
- Add `public/js/distortion-lab.js` which implements `mirrorClaim` and `contradictClaim` output generators, a `pick` helper, slider-to-label synchronization, event handlers for `distortBtn`/`contradictBtn`, and preset loading logic. 
- Populate the script with placeholder hedges, emotions, conspiracies, and `sources` arrays and set the script to update `confidenceMeter` and `sourceText` based on controls. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ca896a0a2c8325a573b6a779c529ea)