### PR TITLE
Add zk lotto & encrypted messenger: routes, APIs, utils, and client JS

### DIFF
--- a/fresh-questionnaire/fresh.gen.ts
+++ b/fresh-questionnaire/fresh.gen.ts
@@ -2,16 +2,30 @@
 // This file SHOULD be checked into source version control.
 // This file is automatically updated during development when running `dev.ts`.
 
+import * as $api_lotto_close from "./routes/api/lotto/close.ts";
+import * as $api_lotto_commit from "./routes/api/lotto/commit.ts";
+import * as $api_lotto_draw from "./routes/api/lotto/draw.ts";
+import * as $api_lotto_verify from "./routes/api/lotto/verify.ts";
 import * as $auth from "./routes/auth.tsx";
+import * as $encrypted_messenger from "./routes/encrypted-messenger.tsx";
 import * as $index from "./routes/index.tsx";
+import * as $lotto from "./routes/lotto.tsx";
+import * as $messenger from "./routes/messenger.tsx";
 import * as $questionnaire from "./routes/questionnaire.tsx";
 import * as $QuestionnaireForm from "./islands/QuestionnaireForm.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
 const manifest = {
   routes: {
+    "./routes/api/lotto/close.ts": $api_lotto_close,
+    "./routes/api/lotto/commit.ts": $api_lotto_commit,
+    "./routes/api/lotto/draw.ts": $api_lotto_draw,
+    "./routes/api/lotto/verify.ts": $api_lotto_verify,
     "./routes/auth.tsx": $auth,
+    "./routes/encrypted-messenger.tsx": $encrypted_messenger,
     "./routes/index.tsx": $index,
+    "./routes/lotto.tsx": $lotto,
+    "./routes/messenger.tsx": $messenger,
     "./routes/questionnaire.tsx": $questionnaire,
   },
   islands: {

--- a/fresh-questionnaire/routes/api/lotto/close.ts
+++ b/fresh-questionnaire/routes/api/lotto/close.ts
@@ -1,0 +1,60 @@
+import { Handlers } from "$fresh/server.ts";
+import {
+  buildMerkleRoot,
+  computeAnchorHash,
+  json,
+  normalizeHashHex,
+  parseInteger,
+  readJsonObject,
+  requireOperator,
+} from "../../../utils/lotto.ts";
+
+function normalizeCommitmentList(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.split(/\n+/).map((item) => item.trim()).filter(Boolean).map((
+      item,
+    ) => normalizeHashHex(item, "commitment"));
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeHashHex(item, "commitment"));
+  }
+  return [];
+}
+
+export const handler: Handlers = {
+  async POST(req) {
+    try {
+      requireOperator(req);
+      const payload = await readJsonObject(req);
+      const commitments = normalizeCommitmentList(payload.commitments);
+      const merkleRoot = await buildMerkleRoot(commitments);
+      const drandRound = parseInteger(
+        payload.drand_round ??
+          Deno.env.get("LOTTO_DEFAULT_DRAND_ROUND_TARGET") ?? 0,
+        "drand_round",
+      );
+      const claimWindowDays = parseInteger(
+        Deno.env.get("LOTTO_CLAIM_WINDOW_DAYS") ?? 7,
+        "LOTTO_CLAIM_WINDOW_DAYS",
+      );
+      const claimDeadline = new Date(Date.now() + claimWindowDays * 86_400_000)
+        .toISOString();
+      const anchorHash = await computeAnchorHash(
+        merkleRoot,
+        commitments.length,
+        drandRound,
+      );
+      return json({
+        ok: true,
+        entry_count: commitments.length,
+        merkle_root: merkleRoot,
+        drand_round: drandRound,
+        anchor_hash: anchorHash,
+        claim_deadline: claimDeadline,
+      });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      return json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+  },
+};

--- a/fresh-questionnaire/routes/api/lotto/commit.ts
+++ b/fresh-questionnaire/routes/api/lotto/commit.ts
@@ -1,0 +1,29 @@
+import { Handlers } from "$fresh/server.ts";
+import {
+  hashHex,
+  json,
+  normalizeHashHex,
+  normalizeToken,
+  readJsonObject,
+} from "../../../utils/lotto.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    try {
+      const payload = await readJsonObject(req);
+      const commitment = normalizeHashHex(payload.commitment, "commitment");
+      const participantToken = normalizeToken(
+        payload.participant_token ?? "anonymous",
+        "participant_token",
+      );
+      const receivedAt = new Date().toISOString();
+      const receipt = await hashHex(
+        `${commitment}:${participantToken}:${receivedAt}`,
+      );
+      return json({ ok: true, commitment, receipt, received_at: receivedAt });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      return json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+  },
+};

--- a/fresh-questionnaire/routes/api/lotto/draw.ts
+++ b/fresh-questionnaire/routes/api/lotto/draw.ts
@@ -1,0 +1,30 @@
+import { Handlers } from "$fresh/server.ts";
+import {
+  chooseWinnerIndex,
+  fetchDrandRandomness,
+  json,
+  parseInteger,
+  readJsonObject,
+  requireOperator,
+} from "../../../utils/lotto.ts";
+
+export const handler: Handlers = {
+  async POST(req) {
+    try {
+      requireOperator(req);
+      const payload = await readJsonObject(req);
+      const entryCount = parseInteger(payload.entry_count, "entry_count");
+      const drandRound = parseInteger(payload.drand_round, "drand_round");
+      const randomness = await fetchDrandRandomness(drandRound);
+      return json({
+        ok: true,
+        drand_round: drandRound,
+        randomness,
+        winner_index: chooseWinnerIndex(randomness, entryCount),
+      });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      return json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+  },
+};

--- a/fresh-questionnaire/routes/api/lotto/verify.ts
+++ b/fresh-questionnaire/routes/api/lotto/verify.ts
@@ -1,0 +1,37 @@
+import { Handlers } from "$fresh/server.ts";
+import {
+  json,
+  normalizeHashHex,
+  parseInteger,
+  readJsonObject,
+  verifyMerkleProof,
+} from "../../../utils/lotto.ts";
+
+function normalizeProof(value: unknown): string[] {
+  if (typeof value === "string") {
+    return value.split(/\n+/).map((item) => item.trim()).filter(Boolean);
+  }
+  if (Array.isArray(value)) return value.map((item) => String(item));
+  return [];
+}
+
+export const handler: Handlers = {
+  async POST(req) {
+    try {
+      const payload = await readJsonObject(req);
+      const commitment = normalizeHashHex(payload.commitment, "commitment");
+      const leafIndex = parseInteger(payload.leaf_index, "leaf_index");
+      const merkleRoot = normalizeHashHex(payload.merkle_root, "merkle_root");
+      const valid = await verifyMerkleProof(
+        commitment,
+        normalizeProof(payload.proof),
+        leafIndex,
+        merkleRoot,
+      );
+      return json({ ok: true, valid });
+    } catch (error) {
+      if (error instanceof Response) return error;
+      return json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+  },
+};

--- a/fresh-questionnaire/routes/encrypted-messenger.tsx
+++ b/fresh-questionnaire/routes/encrypted-messenger.tsx
@@ -1,0 +1,1 @@
+export { default } from "./messenger.tsx";

--- a/fresh-questionnaire/routes/index.tsx
+++ b/fresh-questionnaire/routes/index.tsx
@@ -8,7 +8,7 @@ interface IndexData {
 }
 
 export const handler: Handlers<IndexData> = {
-  async GET(req, ctx) {
+  GET(_req, ctx) {
     return ctx.render({});
   },
 
@@ -62,10 +62,25 @@ export default function IndexPage({ data }: PageProps<IndexData>) {
       <Head>
         <title>begin the questionnaire - a formulation of truth</title>
         <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
-        <style>{`
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="/favicons/favicon-32x32.png"
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="/favicons/favicon-16x16.png"
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href="/favicons/apple-touch-icon.png"
+        />
+        <style>
+          {`
           * {
             margin: 0;
             padding: 0;
@@ -206,6 +221,42 @@ export default function IndexPage({ data }: PageProps<IndexData>) {
             text-decoration: underline;
           }
 
+          .tool-links {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 1rem;
+            margin-top: 2rem;
+          }
+
+          .tool-card {
+            display: block;
+            border: 2px solid #d4a574;
+            border-radius: 10px;
+            padding: 1rem;
+            color: #4a3728;
+            text-decoration: none;
+            background: rgba(255, 248, 236, 0.85);
+            transition: all 0.3s ease;
+          }
+
+          .tool-card:hover {
+            border-color: #8b4513;
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(139, 69, 19, 0.2);
+          }
+
+          .tool-card strong {
+            display: block;
+            color: #8b4513;
+            margin-bottom: 0.35rem;
+          }
+
+          .tool-card span {
+            display: block;
+            font-size: 0.9rem;
+            line-height: 1.45;
+          }
+
           @media (max-width: 640px) {
             .container {
               padding: 2rem;
@@ -219,55 +270,74 @@ export default function IndexPage({ data }: PageProps<IndexData>) {
               font-size: 1rem;
             }
           }
-        `}</style>
+        `}
+        </style>
       </Head>
 
       <div class="container">
-        {data.success ? (
-          <div class="success">
-            <div class="success-icon">✉️</div>
-            <p>{data.message}</p>
-            <p style="margin-top: 1rem; font-size: 0.95rem; font-style: italic;">
-              Click the link in your email to begin the questionnaire.
-            </p>
-          </div>
-        ) : (
-          <>
-            <h1>தொடங்கு</h1>
-            <p class="subtitle">Begin the questionnaire</p>
-
-            <div class="intro">
-              <p>
-                Enter your email to receive a magic link. No password needed—just
-                click the link we send you to begin answering the thirty-five questions.
+        {data.success
+          ? (
+            <div class="success">
+              <div class="success-icon">✉️</div>
+              <p>{data.message}</p>
+              <p style="margin-top: 1rem; font-size: 0.95rem; font-style: italic;">
+                Click the link in your email to begin the questionnaire.
               </p>
             </div>
+          )
+          : (
+            <>
+              <h1>தொடங்கு</h1>
+              <p class="subtitle">Begin the questionnaire</p>
 
-            {data.error && (
-              <div class="error">
-                {data.error}
-              </div>
-            )}
-
-            <form method="POST">
-              <div class="form-group">
-                <label for="email">Email Address</label>
-                <input
-                  type="email"
-                  id="email"
-                  name="email"
-                  placeholder="your@email.com"
-                  required
-                  autofocus
-                />
+              <div class="intro">
+                <p>
+                  Enter your email to receive a magic link. No password
+                  needed—just click the link we send you to begin answering the
+                  thirty-five questions.
+                </p>
               </div>
 
-              <button type="submit">
-                Send Magic Link
-              </button>
-            </form>
-          </>
-        )}
+              {data.error && (
+                <div class="error">
+                  {data.error}
+                </div>
+              )}
+
+              <div class="tool-links" aria-label="public privacy tools">
+                <a class="tool-card" href="/lotto">
+                  <strong>zk lotto</strong>
+                  <span>
+                    Commitment-only drawing with Merkle proof verification.
+                  </span>
+                </a>
+                <a class="tool-card" href="/messenger">
+                  <strong>encrypted messenger</strong>
+                  <span>
+                    Seal and open passphrase-protected notes in your browser.
+                  </span>
+                </a>
+              </div>
+
+              <form method="POST">
+                <div class="form-group">
+                  <label for="email">Email Address</label>
+                  <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    placeholder="your@email.com"
+                    required
+                    autofocus
+                  />
+                </div>
+
+                <button type="submit">
+                  Send Magic Link
+                </button>
+              </form>
+            </>
+          )}
 
         <a href="/" class="home-link">← Return to homepage</a>
       </div>

--- a/fresh-questionnaire/routes/lotto.tsx
+++ b/fresh-questionnaire/routes/lotto.tsx
@@ -1,0 +1,79 @@
+import { Head } from "$fresh/runtime.ts";
+
+export default function LottoPage() {
+  return (
+    <>
+      <Head>
+        <title>zk lotto · a formulation of truth</title>
+        <style>
+          {`
+          :root { color-scheme: dark; --bg:#08070b; --panel:#15111d; --ink:#f7efe1; --muted:#b8a98e; --line:#4a3b61; --gold:#d9af62; --violet:#9b7cff; }
+          * { box-sizing: border-box; }
+          body { margin:0; min-height:100vh; font:16px/1.55 ui-serif, Georgia, serif; color:var(--ink); background:radial-gradient(circle at 20% 0%, #25143c 0, transparent 34rem), var(--bg); }
+          main { width:min(980px, calc(100% - 2rem)); margin:0 auto; padding:4rem 0; }
+          .eyebrow { color:var(--gold); letter-spacing:.24em; text-transform:uppercase; font:700 .78rem ui-sans-serif, system-ui; }
+          h1 { font-size:clamp(2.5rem, 8vw, 6rem); line-height:.9; margin:.5rem 0 1rem; }
+          .grid { display:grid; gap:1rem; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); margin-top:2rem; }
+          section { background:color-mix(in srgb, var(--panel) 88%, transparent); border:1px solid var(--line); border-radius:24px; padding:1.25rem; box-shadow:0 24px 70px rgb(0 0 0 / .35); }
+          label { display:block; margin:.75rem 0 .25rem; color:var(--muted); font:700 .78rem ui-sans-serif, system-ui; text-transform:uppercase; letter-spacing:.08em; }
+          input, textarea { width:100%; border:1px solid var(--line); border-radius:14px; background:#0d0a12; color:var(--ink); padding:.85rem; font:14px ui-monospace, SFMono-Regular, Menlo, monospace; }
+          textarea { min-height:8rem; resize:vertical; }
+          button, a.pill { display:inline-block; margin-top:.9rem; border:0; border-radius:999px; background:linear-gradient(135deg, var(--gold), var(--violet)); color:#09060d; padding:.8rem 1.15rem; font-weight:800; cursor:pointer; text-decoration:none; }
+          output, pre { display:block; white-space:pre-wrap; overflow-wrap:anywhere; background:#0d0a12; border:1px solid var(--line); border-radius:14px; padding:1rem; min-height:3rem; }
+          a { color:var(--gold); }
+        `}
+        </style>
+      </Head>
+      <main>
+        <a class="pill" href="/">← home</a>
+        <p class="eyebrow">publicly auditable · private entries</p>
+        <h1>zk lotto</h1>
+        <p>
+          Commit locally, reveal only when you choose, and verify inclusion
+          against a Merkle anchor. The Deno endpoint accepts 32-byte commitment
+          hashes; draw finality is tied to a drand round.
+        </p>
+        <div class="grid">
+          <section>
+            <h2>1 · make commitment</h2>
+            <label for="secret">secret phrase</label>
+            <input id="secret" placeholder="keep this private" />
+            <label for="salt">salt</label>
+            <input id="salt" placeholder="random salt" />
+            <button id="commit" type="button">hash commitment</button>
+            <label>commitment</label>
+            <output id="commitment"></output>
+            <button id="submit" type="button">submit commitment</button>
+            <label>receipt</label>
+            <output id="receipt"></output>
+          </section>
+          <section>
+            <h2>2 · verify proof</h2>
+            <label for="verifyCommitment">commitment</label>
+            <input id="verifyCommitment" placeholder="64 hex characters" />
+            <label for="proof">proof hashes, one per line</label>
+            <textarea id="proof"></textarea>
+            <label for="leafIndex">leaf index</label>
+            <input id="leafIndex" type="number" min="0" value="0" />
+            <label for="root">merkle root</label>
+            <input id="root" placeholder="64 hex characters" />
+            <button id="verify" type="button">verify inclusion</button>
+            <label>verification</label>
+            <output id="verification"></output>
+          </section>
+          <section>
+            <h2>3 · audit recipe</h2>
+            <pre>{`anchor_hash = sha256(merkle_root + ':' + entry_count + ':' + drand_round)
+winner_index = int(drand_randomness, 16) % entry_count`}</pre>
+            <p>
+              Operator close is served by{" "}
+              <code>/api/lotto/close</code>; membership is checked at{" "}
+              <code>/api/lotto/verify</code>.
+            </p>
+          </section>
+        </div>
+      </main>
+      <script src="/js/lotto.js"></script>
+    </>
+  );
+}

--- a/fresh-questionnaire/routes/messenger.tsx
+++ b/fresh-questionnaire/routes/messenger.tsx
@@ -1,0 +1,88 @@
+import { Head } from "$fresh/runtime.ts";
+
+export default function EncryptedMessengerPage() {
+  return (
+    <>
+      <Head>
+        <title>encrypted messenger · a formulation of truth</title>
+        <style>
+          {`
+          :root { color-scheme: dark; --bg:#05070a; --panel:#101820; --ink:#eef7f2; --muted:#9fb8ad; --line:#27433a; --green:#65e3ad; --blue:#7ca7ff; }
+          * { box-sizing:border-box; }
+          body { margin:0; min-height:100vh; font:16px/1.55 ui-sans-serif, system-ui; color:var(--ink); background:radial-gradient(circle at 80% 5%, #133c4f 0, transparent 34rem), var(--bg); }
+          main { width:min(1040px, calc(100% - 2rem)); margin:0 auto; padding:4rem 0; }
+          .eyebrow { color:var(--green); letter-spacing:.24em; text-transform:uppercase; font-weight:800; font-size:.76rem; }
+          h1 { font-size:clamp(2.5rem, 8vw, 5.6rem); line-height:.92; margin:.5rem 0 1rem; }
+          .grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(300px, 1fr)); gap:1rem; margin-top:2rem; }
+          section { background:color-mix(in srgb, var(--panel) 88%, transparent); border:1px solid var(--line); border-radius:24px; padding:1.25rem; box-shadow:0 24px 70px rgb(0 0 0 / .35); }
+          label { display:block; margin:.75rem 0 .25rem; color:var(--muted); font-size:.78rem; font-weight:800; text-transform:uppercase; letter-spacing:.08em; }
+          textarea, input { width:100%; border:1px solid var(--line); border-radius:14px; background:#071015; color:var(--ink); padding:.85rem; font:14px ui-monospace, SFMono-Regular, Menlo, monospace; }
+          textarea { min-height:10rem; resize:vertical; }
+          button, a.pill { display:inline-block; margin-top:.9rem; border:0; border-radius:999px; background:linear-gradient(135deg, var(--green), var(--blue)); color:#03100b; padding:.8rem 1.15rem; font-weight:900; cursor:pointer; text-decoration:none; }
+          output, pre { display:block; white-space:pre-wrap; overflow-wrap:anywhere; background:#071015; border:1px solid var(--line); border-radius:14px; padding:1rem; min-height:3rem; }
+        `}
+        </style>
+      </Head>
+      <main>
+        <a class="pill" href="/">← home</a>
+        <p class="eyebrow">client side · AES-GCM · no server plaintext</p>
+        <h1>encrypted messenger</h1>
+        <p>
+          Compose sealed notes in the browser. The passphrase never leaves this
+          page; ciphertext can be copied into any channel and reopened here.
+        </p>
+        <div class="grid">
+          <section>
+            <h2>seal a message</h2>
+            <label for="plain">plaintext</label>
+            <textarea
+              id="plain"
+              placeholder="write what only the holder of the passphrase should read"
+            >
+            </textarea>
+            <label for="passphrase">passphrase</label>
+            <input
+              id="passphrase"
+              type="password"
+              autocomplete="new-password"
+            />
+            <button id="encrypt" type="button">encrypt</button>
+            <label>sealed envelope</label>
+            <output id="cipher"></output>
+          </section>
+          <section>
+            <h2>open a message</h2>
+            <label for="sealed">sealed envelope</label>
+            <textarea
+              id="sealed"
+              placeholder='paste {"v":1,"kdf":"PBKDF2-SHA256",...}'
+            >
+            </textarea>
+            <label for="openPassphrase">passphrase</label>
+            <input
+              id="openPassphrase"
+              type="password"
+              autocomplete="current-password"
+            />
+            <button id="decrypt" type="button">decrypt</button>
+            <label>plaintext</label>
+            <output id="opened"></output>
+          </section>
+          <section>
+            <h2>format</h2>
+            <pre>{`{
+  "v": 1,
+  "kdf": "PBKDF2-SHA256",
+  "iterations": 250000,
+  "cipher": "AES-GCM",
+  "salt": "base64",
+  "iv": "base64",
+  "data": "base64"
+}`}</pre>
+          </section>
+        </div>
+      </main>
+      <script src="/js/messenger.js"></script>
+    </>
+  );
+}

--- a/fresh-questionnaire/static/js/lotto.js
+++ b/fresh-questionnaire/static/js/lotto.js
@@ -1,0 +1,59 @@
+const enc = new TextEncoder();
+const hex = (bytes) =>
+  [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+async function sha256(text) {
+  return hex(await crypto.subtle.digest("SHA-256", enc.encode(text)));
+}
+
+document.getElementById("salt").value = hex(
+  crypto.getRandomValues(new Uint8Array(16)),
+);
+document.getElementById("commit").onclick = async () => {
+  const secret = document.getElementById("secret").value;
+  const salt = document.getElementById("salt").value;
+  document.getElementById("commitment").textContent = await sha256(
+    `${salt}:${secret}`,
+  );
+};
+document.getElementById("submit").onclick = async () => {
+  const commitment = document.getElementById("commitment").textContent.trim();
+  const res = await fetch("/api/lotto/commit", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "accept": "application/json",
+    },
+    body: JSON.stringify({ commitment, participant_token: "browser" }),
+  });
+  document.getElementById("receipt").textContent = JSON.stringify(
+    await res.json(),
+    null,
+    2,
+  );
+};
+document.getElementById("verify").onclick = async () => {
+  const proof = document.getElementById("proof").value.split(/\n+/).map((s) =>
+    s.trim()
+  ).filter(Boolean);
+  const body = {
+    commitment: verifyCommitment.value,
+    proof,
+    leaf_index: leafIndex.value,
+    merkle_root: root.value,
+  };
+  const res = await fetch("/api/lotto/verify", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "accept": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  document.getElementById("verification").textContent = JSON.stringify(
+    await res.json(),
+    null,
+    2,
+  );
+};

--- a/fresh-questionnaire/static/js/messenger.js
+++ b/fresh-questionnaire/static/js/messenger.js
@@ -1,0 +1,69 @@
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const b64 = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)));
+const unb64 = (text) => Uint8Array.from(atob(text), (c) => c.charCodeAt(0));
+
+async function keyFromPassphrase(passphrase, salt, iterations) {
+  const material = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", hash: "SHA-256", salt, iterations },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+document.getElementById("encrypt").onclick = async () => {
+  try {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const iterations = 250000;
+    const key = await keyFromPassphrase(passphrase.value, salt, iterations);
+    const data = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      enc.encode(plain.value),
+    );
+    cipher.textContent = JSON.stringify(
+      {
+        v: 1,
+        kdf: "PBKDF2-SHA256",
+        iterations,
+        cipher: "AES-GCM",
+        salt: b64(salt),
+        iv: b64(iv),
+        data: b64(data),
+      },
+      null,
+      2,
+    );
+  } catch (err) {
+    cipher.textContent = `encryption failed: ${err.message}`;
+  }
+};
+
+document.getElementById("decrypt").onclick = async () => {
+  try {
+    const envelope = JSON.parse(sealed.value);
+    const key = await keyFromPassphrase(
+      openPassphrase.value,
+      unb64(envelope.salt),
+      envelope.iterations || 250000,
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: unb64(envelope.iv) },
+      key,
+      unb64(envelope.data),
+    );
+    opened.textContent = dec.decode(plaintext);
+  } catch (err) {
+    opened.textContent = `decryption failed: ${err.message}`;
+  }
+};

--- a/fresh-questionnaire/utils/lotto.ts
+++ b/fresh-questionnaire/utils/lotto.ts
@@ -1,0 +1,244 @@
+const HEX_32_BYTE_RE = /^(?:0x)?[0-9a-fA-F]{64}$/;
+
+export interface LottoCloseResult {
+  ok: true;
+  entry_count: number;
+  merkle_root: string;
+  drand_round: number;
+  anchor_hash: string;
+  claim_deadline: string;
+}
+
+export function normalizeToken(
+  value: unknown,
+  field: string,
+  maxLength = 256,
+): string {
+  const token = String(value ?? "").trim();
+  if (!token) {
+    throw new Response(JSON.stringify({ error: `${field} is required` }), {
+      status: 400,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+  if (token.length > maxLength) {
+    throw new Response(JSON.stringify({ error: `${field} is too long` }), {
+      status: 400,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+  return token;
+}
+
+export function normalizeHashHex(value: unknown, field: string): string {
+  const hash = normalizeToken(value, field, 66).toLowerCase();
+  if (!HEX_32_BYTE_RE.test(hash)) {
+    throw new Response(
+      JSON.stringify({ error: `${field} must be 32-byte hex` }),
+      {
+        status: 400,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return hash.startsWith("0x") ? hash.slice(2) : hash;
+}
+
+export function parseInteger(value: unknown, field: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw new Response(
+      JSON.stringify({ error: `${field} must be an integer` }),
+      {
+        status: 400,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return parsed;
+}
+
+export async function hashBytes(data: Uint8Array): Promise<Uint8Array> {
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", buffer));
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}
+
+export async function hashHex(value: string): Promise<string> {
+  return bytesToHex(await hashBytes(new TextEncoder().encode(value)));
+}
+
+async function leafHash(commitment: string): Promise<Uint8Array> {
+  return await hashBytes(new TextEncoder().encode(commitment));
+}
+
+export async function buildMerkleRoot(commitments: string[]): Promise<string> {
+  if (commitments.length === 0) {
+    throw new Response(JSON.stringify({ error: "No commitments available" }), {
+      status: 400,
+      headers: { "content-type": "application/json; charset=utf-8" },
+    });
+  }
+
+  let level = await Promise.all(
+    commitments.map((commitment) => leafHash(commitment)),
+  );
+  while (level.length > 1) {
+    const nextLevel: Uint8Array[] = [];
+    for (let i = 0; i < level.length; i += 2) {
+      const left = level[i];
+      const right = level[i + 1] ?? left;
+      const pair = new Uint8Array(left.length + right.length);
+      pair.set(left);
+      pair.set(right, left.length);
+      nextLevel.push(await hashBytes(pair));
+    }
+    level = nextLevel;
+  }
+  return bytesToHex(level[0]);
+}
+
+export async function verifyMerkleProof(
+  commitment: string,
+  proofHashes: string[],
+  leafIndex: number,
+  merkleRoot: string,
+): Promise<boolean> {
+  let current = await leafHash(commitment);
+  let index = leafIndex;
+
+  for (const proofHash of proofHashes) {
+    const sibling = hexToBytes(normalizeHashHex(proofHash, "proof_hash"));
+    const pair = new Uint8Array(current.length + sibling.length);
+    if (index % 2 === 0) {
+      pair.set(current);
+      pair.set(sibling, current.length);
+    } else {
+      pair.set(sibling);
+      pair.set(current, sibling.length);
+    }
+    current = await hashBytes(pair);
+    index = Math.floor(index / 2);
+  }
+
+  return bytesToHex(current) === normalizeHashHex(merkleRoot, "merkle_root");
+}
+
+export async function computeAnchorHash(
+  merkleRoot: string,
+  entryCount: number,
+  drandRound: number,
+): Promise<string> {
+  return await hashHex(`${merkleRoot}:${entryCount}:${drandRound}`);
+}
+
+export async function fetchDrandRandomness(
+  roundNumber: number,
+): Promise<string> {
+  const template = Deno.env.get("LOTTO_DRAND_URL_TEMPLATE") ??
+    "https://api.drand.sh/public/{round}";
+  const response = await fetch(
+    template.replace("{round}", String(roundNumber)),
+  );
+  if (!response.ok) {
+    throw new Response(
+      JSON.stringify({ error: "Unable to fetch drand randomness" }),
+      {
+        status: 502,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  const beacon = await response.json() as { randomness?: string };
+  const randomness = beacon.randomness?.trim().toLowerCase();
+  if (!randomness) {
+    throw new Response(
+      JSON.stringify({ error: "drand response missing randomness" }),
+      {
+        status: 502,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return randomness;
+}
+
+export function chooseWinnerIndex(
+  randomnessHex: string,
+  entryCount: number,
+): number {
+  if (entryCount <= 0) {
+    throw new Response(
+      JSON.stringify({ error: "entry_count must be positive" }),
+      {
+        status: 400,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return Number(BigInt(`0x${randomnessHex}`) % BigInt(entryCount));
+}
+
+export function requireOperator(req: Request): void {
+  const configured = Deno.env.get("LOTTO_OPERATOR_TOKEN") ?? "";
+  if (!configured) {
+    throw new Response(
+      JSON.stringify({ error: "lotto operator token not configured" }),
+      {
+        status: 503,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  const supplied = (req.headers.get("x-lotto-operator-token") ??
+    req.headers.get("authorization")?.replace(/^Bearer\s+/i, "") ?? "").trim();
+  if (supplied !== configured) {
+    throw new Response(
+      JSON.stringify({ error: "operator authorization failed" }),
+      {
+        status: 403,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+}
+
+export async function readJsonObject(
+  req: Request,
+): Promise<Record<string, unknown>> {
+  const payload = await req.json();
+  if (!payload || Array.isArray(payload) || typeof payload !== "object") {
+    throw new Response(
+      JSON.stringify({ error: "JSON payload must be an object" }),
+      {
+        status: 400,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    );
+  }
+  return payload as Record<string, unknown>;
+}
+
+export function json(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...init.headers,
+    },
+  });
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -974,6 +974,11 @@ animation: shimmer 8s ease-in-out infinite;
   <p>We believe in radical privacy. All data is encrypted end-to-end. No tracking. No third-party analytics. Your thoughts remain yours.</p>
 </a>
 
+<a href="/lotto" class="sidebar-card">
+  <h3>zk lotto</h3>
+  <p>Enter a commitment-only public drawing whose Merkle anchor and drand round can be audited after close.</p>
+</a>
+
 <div class="sidebar-card" id="quote-card">
   <h3>Contemplations</h3>
   <p id="quote-text"></p>
@@ -1266,6 +1271,12 @@ See <em>Abhinavabhāratī</em>, Abhinavagupta's commentary on Bharata's <em>Nā�
 <a href="/contact.html" class="sidebar-card">
   <h3>Contact</h3>
   <p>Reach out to share feedback, ask questions, or discuss collaboration opportunities. All inquiries welcome.</p>
+</a>
+
+
+<a href="/messenger" class="sidebar-card">
+  <h3>Encrypted Messenger</h3>
+  <p>Seal and open passphrase-protected notes entirely in your browser; plaintext never has to leave your device.</p>
 </a>
 </aside>
 


### PR DESCRIPTION
### Motivation

- Introduce two privacy-first utilities — a commitment-based `zk lotto` and a client-side `encrypted messenger` — so users can create auditable public drawings and seal/unseal passphrase-protected notes in the browser.
- Provide server-side helpers and endpoints to support Merkle-based commitment workflows and drand-based randomness for verifiable draws.

### Description

- Added a new helper library `utils/lotto.ts` implementing hashing, Merkle tree construction/verification, drand randomness fetching, input normalization, and operator authorization helpers (`computeAnchorHash`, `buildMerkleRoot`, `verifyMerkleProof`, `chooseWinnerIndex`, `requireOperator`, etc.).
- Added lotto API endpoints under `routes/api/lotto/*`: `commit.ts` (submit commitment), `close.ts` (operator close that builds Merkle root and anchor), `draw.ts` (fetch drand randomness and choose winner), and `verify.ts` (verify Merkle inclusion proofs).
- Added UI routes and client assets for both tools: `routes/lotto.tsx` and `static/js/lotto.js` for the zk-lotto UI and interactions, and `routes/messenger.tsx` plus `static/js/messenger.js` for the encrypted messenger UI and client-side AES-GCM/PBKDF2 logic; also added `routes/encrypted-messenger.tsx` as a re-export of `messenger.tsx`.
- Updated the homepage and site manifests to surface the new tools: modified `routes/index.tsx` to add tool cards and UI refinements, updated `public/index.html` to include sidebar links to `/lotto` and `/messenger`, and updated `fresh.gen.ts` to register the new routes and APIs.

### Testing

- No automated tests were added for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c3de89108325bd279b2c76dbaf9c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a zero-knowledge lotto application enabling commitment-based lottery functionality.
  * Added an encrypted messenger tool for secure, passphrase-protected messaging operating entirely in the browser.
  * Updated the home page to include links to the new lotto and messenger tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyagrodha/aformulationoftruth/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->