### PR TITLE
Add Monero tip address generation via remote wallet-rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,7 @@ vps-server.js
 !README.md
 !DATABASE_SETUP.md
 !NETWORK_SETUP.md
+!MONERO_TIPS_SETUP.md
 !public/SHUFFLE-IMPLEMENTATION.md
 
 # Allow project configuration tracked in this repository

--- a/MONERO_TIPS_SETUP.md
+++ b/MONERO_TIPS_SETUP.md
@@ -1,0 +1,79 @@
+# Monero Tips Setup
+
+The site can hand each visitor a fresh Monero subaddress for tips. Address
+generation is done by a `monero-wallet-rpc` instance that you run yourself —
+for example on a home Windows 11 machine — and the web server reaches it over
+the network. The wallet's spend keys never touch the web server; it only asks
+the wallet RPC to derive new subaddresses.
+
+## 1. Run monero-wallet-rpc on the wallet machine (Windows 11)
+
+Download the official Monero CLI tools from https://www.getmonero.org/downloads/
+and unzip them. Then, from PowerShell in that folder:
+
+```powershell
+.\monero-wallet-rpc.exe `
+  --wallet-file C:\monero\tips-wallet `
+  --password-file C:\monero\tips-wallet.pass `
+  --rpc-bind-port 18083 `
+  --rpc-bind-ip 0.0.0.0 `
+  --confirm-external-bind `
+  --rpc-login tipuser:CHOOSE_A_STRONG_PASSWORD `
+  --daemon-address node.monerodevs.org:18089
+```
+
+Notes:
+
+- Use a **view-only or dedicated tips wallet**, not your main wallet.
+- `--rpc-login` is required for any non-localhost binding; the server speaks
+  HTTP digest auth to it.
+- Allow inbound TCP 18083 in Windows Defender Firewall **only** for the
+  network interface the web server uses (see next section).
+- If you don't want to run a full node on the same machine, point
+  `--daemon-address` at a remote node you trust.
+
+## 2. Make the wallet reachable from the web server
+
+Do **not** expose port 18083 directly to the internet. Pick one:
+
+- **VPN / overlay network (recommended):** put the Windows machine and the
+  web server on the same WireGuard or Tailscale network and use the private
+  address (e.g. `http://100.x.y.z:18083`).
+- **SSH reverse tunnel:** from the Windows machine,
+  `ssh -N -R 18083:localhost:18083 user@your-server`, then the server uses
+  `http://127.0.0.1:18083`.
+
+## 3. Configure the web server
+
+Set these environment variables where the Node server runs:
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `MONERO_WALLET_RPC_URL` | yes | Base URL of the wallet RPC, e.g. `http://100.64.0.12:18083` |
+| `MONERO_WALLET_RPC_USERNAME` | with `--rpc-login` | Username from `--rpc-login` |
+| `MONERO_WALLET_RPC_PASSWORD` | with `--rpc-login` | Password from `--rpc-login` |
+| `MONERO_WALLET_ACCOUNT_INDEX` | no | Wallet account to derive subaddresses from (default `0`) |
+
+If `MONERO_WALLET_RPC_URL` is unset, the tips endpoints stay disabled and
+return `503` — the rest of the site is unaffected.
+
+## 4. Endpoints
+
+- `GET /api/tips/monero/address` — public, rate-limited; returns
+  `{ "address": "8...", "addressIndex": n }`, a freshly created subaddress
+  labeled with the request timestamp.
+- `GET /api/tips/monero/health` — admin-only; reports whether the wallet RPC
+  is configured and reachable.
+
+The tip widget on `/contact.html` calls the address endpoint and lets the
+visitor copy the address.
+
+## 5. Verify
+
+```bash
+curl -s https://your-site/api/tips/monero/address
+```
+
+You should get a fresh subaddress each call (rate limit: 5/minute per IP).
+Incoming tips appear in the tips wallet, one subaddress per generated request,
+labeled `tip:<timestamp>`.

--- a/public/contact.html
+++ b/public/contact.html
@@ -493,6 +493,20 @@
                 <em>Support & Donations:</em> This site operates independently without advertising or data harvesting. If you wish to support its ongoing development and hosting costs, inquiries about donations are welcome. You may also consider patronizing <a href="https://billing.flokinet.is/aff.php?aff=543" target="_blank" rel="noopener">Flokinet</a>, the privacy-focused hosting provider that makes this site possible.
             </p>
 
+            <!-- Monero tip address widget -->
+            <div class="newsletter-section" id="monero-tip-section">
+                <div class="newsletter-title">◈ Tip in Monero ◈</div>
+                <p class="newsletter-description">
+                    Prefer to tip privately? Request a one-time Monero address below. Each address is
+                    generated fresh for you alone, so your tip stays unlinkable to anyone else's.
+                </p>
+                <button type="button" class="subscribe-button" id="monero-tip-button">
+                    Generate Tip Address
+                </button>
+                <div class="message" id="monero-tip-message" style="display: none;"></div>
+                <div id="monero-tip-address" style="display: none; margin-top: 1rem; padding: 0.75rem; border: 1px dashed var(--border-color); border-radius: 8px; font-family: monospace; font-size: 0.85rem; word-break: break-all; cursor: pointer;" title="Click to copy"></div>
+            </div>
+
             <div class="ornament" aria-hidden="true">
                 <svg viewBox="0 0 120 14" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
                     <path d="M6 7 C24 1, 36 13, 54 7 C72 1, 84 13, 102 7" stroke-linecap="round" stroke-linejoin="round"/>
@@ -662,7 +676,6 @@
     </div>
 
     <!-- Scripts -->
-HEAD
     <script src="/js/api-failover.js"></script>
     <script>
         // Newsletter subscription handler
@@ -722,6 +735,51 @@ HEAD
                 submitButton.textContent = 'Subscribe';
             }
         }
+
+        // Monero tip address handler
+        const tipButton = document.getElementById('monero-tip-button');
+        const tipMessage = document.getElementById('monero-tip-message');
+        const tipAddressDiv = document.getElementById('monero-tip-address');
+
+        function showTipMessage(text, type) {
+            tipMessage.textContent = text;
+            tipMessage.className = `message ${type}`;
+            tipMessage.style.display = 'block';
+        }
+
+        tipButton.addEventListener('click', async () => {
+            try {
+                tipButton.disabled = true;
+                tipButton.textContent = 'Generating...';
+                tipAddressDiv.style.display = 'none';
+
+                const response = await apiGet('/api/tips/monero/address', { timeout: 15000 });
+                const data = await response.json();
+
+                if (response.ok && data.address) {
+                    tipAddressDiv.textContent = data.address;
+                    tipAddressDiv.style.display = 'block';
+                    showTipMessage('✓ Fresh address generated — click it to copy. Thank you!', 'success');
+                } else {
+                    showTipMessage(`✗ ${data.message || 'Unable to generate an address right now'}`, 'error');
+                }
+            } catch (error) {
+                console.error('Tip address error:', error);
+                showTipMessage('✗ Could not reach the wallet — please try again later', 'error');
+            } finally {
+                tipButton.disabled = false;
+                tipButton.textContent = 'Generate Tip Address';
+            }
+        });
+
+        tipAddressDiv.addEventListener('click', async () => {
+            try {
+                await navigator.clipboard.writeText(tipAddressDiv.textContent);
+                showTipMessage('✓ Address copied to clipboard', 'success');
+            } catch (error) {
+                showTipMessage('Copy failed — please select and copy the address manually', 'info');
+            }
+        });
 
         form.addEventListener('submit', async (e) => {
             e.preventDefault();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,6 +31,8 @@ import { emailService } from "./services/emailService";
 import { pdfService } from "./services/pdfService";
 import { questionService } from "./services/questionService";
 import { vpsStorageService } from "./services/vpsStorageService";
+import { moneroWalletService } from "./services/moneroWalletService";
+import rateLimit from "express-rate-limit";
 import { encryptionService } from "./services/encryptionService";
 import { responseEncryptionService } from "./services/responseEncryptionService";
 
@@ -550,6 +552,42 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post("/api/newsletter/signup", handleNewsletterSignup);
   app.post("/api/newsletter/subscribe", handleNewsletterSignup);
+
+  // Monero tip address generation — each visitor gets a fresh subaddress
+  // from the wallet-rpc instance configured via MONERO_WALLET_RPC_URL.
+  // Stricter limit than the global one since each call creates wallet state.
+  const tipAddressLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { message: "Too many address requests, please wait a moment" },
+  });
+
+  app.get("/api/tips/monero/address", tipAddressLimiter, async (req, res) => {
+    try {
+      if (!moneroWalletService.isConfigured) {
+        return res.status(503).json({ message: "Monero tips are not configured" });
+      }
+
+      const tip = await moneroWalletService.createTipAddress(
+        `tip:${new Date().toISOString()}`
+      );
+
+      res.json({ address: tip.address, addressIndex: tip.addressIndex });
+    } catch (error) {
+      console.error("Monero tip address error:", error);
+      res.status(502).json({ message: "Unable to generate tip address right now" });
+    }
+  });
+
+  app.get("/api/tips/monero/health", isAdmin, async (req, res) => {
+    if (!moneroWalletService.isConfigured) {
+      return res.json({ configured: false, healthy: false });
+    }
+    const healthy = await moneroWalletService.healthCheck();
+    res.json({ configured: true, healthy });
+  });
 
   // Admin routes (temporarily disabled - storage methods need implementation)
   /*

--- a/server/services/moneroWalletService.ts
+++ b/server/services/moneroWalletService.ts
@@ -1,0 +1,147 @@
+import crypto from 'crypto';
+// Talks to a monero-wallet-rpc instance over JSON-RPC using native fetch.
+// The wallet can live anywhere reachable from this server (e.g. a home
+// machine exposed through a VPN/tunnel) — see MONERO_TIPS_SETUP.md.
+
+interface MoneroWalletConfig {
+  rpcUrl: string;
+  rpcUsername: string;
+  rpcPassword: string;
+  accountIndex: number;
+}
+
+export interface TipAddress {
+  address: string;
+  addressIndex: number;
+  accountIndex: number;
+}
+
+interface JsonRpcResponse<T> {
+  id: string;
+  jsonrpc: string;
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+export class MoneroWalletService {
+  private config: MoneroWalletConfig;
+  public readonly isConfigured: boolean;
+
+  constructor() {
+    this.config = {
+      rpcUrl: (process.env.MONERO_WALLET_RPC_URL || '').replace(/\/$/, ''),
+      rpcUsername: process.env.MONERO_WALLET_RPC_USERNAME || '',
+      rpcPassword: process.env.MONERO_WALLET_RPC_PASSWORD || '',
+      accountIndex: Number.parseInt(process.env.MONERO_WALLET_ACCOUNT_INDEX || '0', 10),
+    };
+
+    // Monero tips are optional — routes return 503 when unconfigured
+    this.isConfigured = !!this.config.rpcUrl;
+  }
+
+  // monero-wallet-rpc started with --rpc-login only accepts HTTP digest auth
+  // (RFC 7616, MD5 + qop=auth), which fetch does not speak natively.
+  private buildDigestHeader(challenge: string, method: string, uri: string): string | null {
+    const params: Record<string, string> = {};
+    for (const match of challenge.matchAll(/(\w+)=(?:"([^"]*)"|([^,\s]+))/g)) {
+      params[match[1]] = match[2] ?? match[3];
+    }
+    if (!params.realm || !params.nonce) {
+      return null;
+    }
+
+    const md5 = (data: string) => crypto.createHash('md5').update(data).digest('hex');
+    const cnonce = crypto.randomBytes(8).toString('hex');
+    const nc = '00000001';
+    const ha1 = md5(`${this.config.rpcUsername}:${params.realm}:${this.config.rpcPassword}`);
+    const ha2 = md5(`${method}:${uri}`);
+    const qop = params.qop ? 'auth' : undefined;
+    const response = qop
+      ? md5(`${ha1}:${params.nonce}:${nc}:${cnonce}:${qop}:${ha2}`)
+      : md5(`${ha1}:${params.nonce}:${ha2}`);
+
+    const parts = [
+      `username="${this.config.rpcUsername}"`,
+      `realm="${params.realm}"`,
+      `nonce="${params.nonce}"`,
+      `uri="${uri}"`,
+      `response="${response}"`,
+      'algorithm=MD5',
+    ];
+    if (qop) {
+      parts.push(`qop=${qop}`, `nc=${nc}`, `cnonce="${cnonce}"`);
+    }
+    if (params.opaque) {
+      parts.push(`opaque="${params.opaque}"`);
+    }
+    return `Digest ${parts.join(', ')}`;
+  }
+
+  private async rpcCall<T>(rpcMethod: string, rpcParams: Record<string, unknown> = {}): Promise<T> {
+    if (!this.isConfigured) {
+      throw new Error('Monero wallet RPC is not configured');
+    }
+
+    const url = `${this.config.rpcUrl}/json_rpc`;
+    const body = JSON.stringify({ jsonrpc: '2.0', id: '0', method: rpcMethod, params: rpcParams });
+    const doPost = (headers: Record<string, string>) => {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+      return fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body,
+        signal: controller.signal,
+      }).finally(() => clearTimeout(timeoutId));
+    };
+
+    let response = await doPost({});
+
+    if (response.status === 401 && this.config.rpcUsername) {
+      const challenge = response.headers.get('www-authenticate');
+      const authHeader = challenge && this.buildDigestHeader(challenge, 'POST', '/json_rpc');
+      if (authHeader) {
+        response = await doPost({ Authorization: authHeader });
+      }
+    }
+
+    if (!response.ok) {
+      throw new Error(`Monero wallet RPC HTTP error: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as JsonRpcResponse<T>;
+    if (payload.error) {
+      throw new Error(`Monero wallet RPC error ${payload.error.code}: ${payload.error.message}`);
+    }
+    if (payload.result === undefined) {
+      throw new Error('Monero wallet RPC returned no result');
+    }
+    return payload.result;
+  }
+
+  // Generate a fresh subaddress so each tip is unlinkable to previous ones
+  async createTipAddress(label: string): Promise<TipAddress> {
+    const result = await this.rpcCall<{ address: string; address_index: number }>('create_address', {
+      account_index: this.config.accountIndex,
+      label,
+    });
+
+    return {
+      address: result.address,
+      addressIndex: result.address_index,
+      accountIndex: this.config.accountIndex,
+    };
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.rpcCall<{ version: number }>('get_version');
+      return true;
+    } catch (error) {
+      console.error('Monero wallet RPC health check failed:', error);
+      return false;
+    }
+  }
+}
+
+export const moneroWalletService = new MoneroWalletService();

--- a/tests/unit/moneroWalletService.test.ts
+++ b/tests/unit/moneroWalletService.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { MoneroWalletService } from '../../server/services/moneroWalletService';
+
+const RPC_URL = 'http://127.0.0.1:18083';
+
+function jsonResponse(body: unknown, init: { status?: number; headers?: Record<string, string> } = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'Content-Type': 'application/json', ...init.headers },
+  });
+}
+
+describe('MoneroWalletService', () => {
+  const originalEnv = process.env;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, MONERO_WALLET_RPC_URL: RPC_URL };
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('is not configured without MONERO_WALLET_RPC_URL', async () => {
+    delete process.env.MONERO_WALLET_RPC_URL;
+    const service = new MoneroWalletService();
+
+    expect(service.isConfigured).toBe(false);
+    await expect(service.createTipAddress('tip:test')).rejects.toThrow('not configured');
+  });
+
+  it('creates a tip address via create_address', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: '0',
+        jsonrpc: '2.0',
+        result: { address: '87TipSubaddress', address_index: 7 },
+      })
+    );
+
+    const service = new MoneroWalletService();
+    const tip = await service.createTipAddress('tip:test');
+
+    expect(tip).toEqual({ address: '87TipSubaddress', addressIndex: 7, accountIndex: 0 });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${RPC_URL}/json_rpc`);
+    const body = JSON.parse(options.body as string);
+    expect(body.method).toBe('create_address');
+    expect(body.params).toEqual({ account_index: 0, label: 'tip:test' });
+  });
+
+  it('retries with a digest Authorization header after a 401 challenge', async () => {
+    process.env.MONERO_WALLET_RPC_USERNAME = 'tipuser';
+    process.env.MONERO_WALLET_RPC_PASSWORD = 'secret';
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response('Unauthorized', {
+          status: 401,
+          headers: {
+            'WWW-Authenticate':
+              'Digest qop="auth", algorithm=MD5, realm="monero-rpc", nonce="abc123", stale=false',
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          id: '0',
+          jsonrpc: '2.0',
+          result: { address: '88AuthedSubaddress', address_index: 1 },
+        })
+      );
+
+    const service = new MoneroWalletService();
+    const tip = await service.createTipAddress('tip:test');
+
+    expect(tip.address).toBe('88AuthedSubaddress');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const retryHeaders = (fetchMock.mock.calls[1] as [string, RequestInit])[1]
+      .headers as Record<string, string>;
+    expect(retryHeaders.Authorization).toMatch(/^Digest /);
+    expect(retryHeaders.Authorization).toContain('username="tipuser"');
+    expect(retryHeaders.Authorization).toContain('realm="monero-rpc"');
+    expect(retryHeaders.Authorization).toContain('nonce="abc123"');
+    expect(retryHeaders.Authorization).toContain('qop=auth');
+    expect(retryHeaders.Authorization).toMatch(/response="[0-9a-f]{32}"/);
+  });
+
+  it('propagates wallet RPC errors', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        id: '0',
+        jsonrpc: '2.0',
+        error: { code: -21, message: 'Wallet is busy' },
+      })
+    );
+
+    const service = new MoneroWalletService();
+    await expect(service.createTipAddress('tip:test')).rejects.toThrow('Wallet is busy');
+  });
+
+  it('reports unhealthy when the wallet is unreachable', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+
+    const service = new MoneroWalletService();
+    await expect(service.healthCheck()).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Each visitor can request a fresh subaddress for tips, generated by a
monero-wallet-rpc instance reachable over the network (e.g. a home
machine behind a VPN/tunnel) and configured via MONERO_WALLET_RPC_URL,
MONERO_WALLET_RPC_USERNAME and MONERO_WALLET_RPC_PASSWORD.

- server/services/moneroWalletService.ts: JSON-RPC client with the HTTP
  digest auth that --rpc-login requires; create_address per tip request
- server/routes.ts: GET /api/tips/monero/address (public, 5/min rate
  limit) and GET /api/tips/monero/health (admin)
- public/contact.html: tip widget in the donations section with
  click-to-copy; also removed a stray merge-conflict 'HEAD' line
- MONERO_TIPS_SETUP.md: wallet-rpc setup for Windows 11 + tunnel options
- tests/unit/moneroWalletService.test.ts: unit tests incl. digest
  challenge/response; verified live against a mock digest-auth RPC

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2LYctR5rHFDpEw9PAqXKK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Monero tip widget on the contact page, letting visitors request a one-time tip address and copy it easily.
  * Added Monero tip API support with rate limiting and a health check for administrators.

* **Documentation**
  * Added setup and usage notes for Monero tipping, including connection options, expected behavior, and verification steps.

* **Bug Fixes**
  * Ensured the Monero tips documentation is included in tracking so it appears in the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->