### PR TITLE
Port Prolegomenon landing page to Deno Fresh

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -19,7 +19,9 @@ import * as $gate from './routes/gate.tsx';
 import * as $index from './routes/index.tsx';
 import * as $login from './routes/login.tsx';
 import * as $questionnaire from './routes/questionnaire.tsx';
+import * as $questions from './routes/questions.tsx';
 import * as $GateQuestionnaire from './islands/GateQuestionnaire.tsx';
+import * as $QuaternarySpheroid from './islands/QuaternarySpheroid.tsx';
 import type { Manifest } from '$fresh/server.ts';
 
 const manifest = {
@@ -41,9 +43,11 @@ const manifest = {
     './routes/index.tsx': $index,
     './routes/login.tsx': $login,
     './routes/questionnaire.tsx': $questionnaire,
+    './routes/questions.tsx': $questions,
   },
   islands: {
     './islands/GateQuestionnaire.tsx': $GateQuestionnaire,
+    './islands/QuaternarySpheroid.tsx': $QuaternarySpheroid,
   },
   baseUrl: import.meta.url,
 } satisfies Manifest;

--- a/islands/QuaternarySpheroid.tsx
+++ b/islands/QuaternarySpheroid.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef } from 'preact/hooks';
+
+type Point4 = [number, number, number, number];
+
+const TAU = Math.PI * 2;
+const PALETTE = ['#a83b5b', '#4d4b8b', '#188a82', '#c17b22'];
+
+function makeSphere(count: number): Point4[] {
+  const phi = 0.618033988749895;
+  const psi = 0.414213562373095;
+
+  return Array.from({ length: count }, (_, index) => {
+    const u = (index + 0.5) / count;
+    const a = TAU * ((index * phi) % 1);
+    const b = TAU * ((index * psi) % 1);
+    const inner = Math.sqrt(u);
+    const outer = Math.sqrt(1 - u);
+    return [
+      inner * Math.cos(a),
+      inner * Math.sin(a),
+      outer * Math.cos(b),
+      outer * Math.sin(b),
+    ];
+  });
+}
+
+function ease(value: number) {
+  return value * value * (3 - 2 * value);
+}
+
+function between(
+  progress: number,
+  start: number,
+  end: number,
+  from: number,
+  to: number,
+) {
+  return from + (to - from) * ease((progress - start) / (end - start));
+}
+
+function flight(progress: number, compact: boolean) {
+  const scale = compact ? 0.58 : 1;
+  const stops = [
+    { t: 0, x: 0, y: 0, r: -8 },
+    { t: 0.28, x: -120 * scale, y: -100 * scale, r: -27 },
+    { t: 0.48, x: -66 * scale, y: -118 * scale, r: 11 },
+    { t: 0.68, x: 38 * scale, y: -65 * scale, r: 29 },
+    { t: 0.84, x: 13 * scale, y: -22 * scale, r: 9 },
+    { t: 1, x: 0, y: 0, r: -8 },
+  ];
+
+  const endIndex = stops.findIndex((stop) => progress <= stop.t);
+  const to = stops[Math.max(1, endIndex)];
+  const from = stops[Math.max(0, endIndex - 1)];
+
+  return {
+    x: between(progress, from.t, to.t, from.x, to.x),
+    y: between(progress, from.t, to.t, from.y, to.y),
+    rotation: between(progress, from.t, to.t, from.r, to.r),
+  };
+}
+
+export default function QuaternarySpheroid() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const stage = stageRef.current;
+    const canvas = canvasRef.current;
+    if (!stage || !canvas) return;
+
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    const points = makeSphere(128);
+    const reducedMotion = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
+    let animationFrame = 0;
+    let width = 0;
+    let height = 0;
+    let pointerX = 0;
+    let pointerY = 0;
+    let targetX = 0;
+    let targetY = 0;
+
+    const resize = () => {
+      const rect = stage.getBoundingClientRect();
+      const pixelRatio = Math.min(globalThis.devicePixelRatio || 1, 2);
+      width = rect.width;
+      height = rect.height;
+      canvas.width = Math.round(width * pixelRatio);
+      canvas.height = Math.round(height * pixelRatio);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+    };
+
+    const move = (event: PointerEvent) => {
+      const rect = stage.getBoundingClientRect();
+      targetX = ((event.clientX - rect.left) / rect.width - 0.5) * 0.7;
+      targetY = ((event.clientY - rect.top) / rect.height - 0.5) * 0.7;
+    };
+
+    const leave = () => {
+      targetX = 0;
+      targetY = 0;
+    };
+
+    const draw = (time: number) => {
+      context.clearRect(0, 0, width, height);
+      const cx = width / 2;
+      const cy = height / 2;
+      const radius = Math.min(width, height) * 0.34;
+      const phase = time * 0.00028;
+      pointerX += (targetX - pointerX) * 0.055;
+      pointerY += (targetY - pointerY) * 0.055;
+
+      const aura = context.createRadialGradient(cx, cy, 2, cx, cy, radius * 1.55);
+      aura.addColorStop(0, 'rgba(7,143,154,.19)');
+      aura.addColorStop(0.45, 'rgba(168,59,91,.09)');
+      aura.addColorStop(1, 'rgba(232,221,197,0)');
+      context.fillStyle = aura;
+      context.beginPath();
+      context.arc(cx, cy, radius * 1.55, 0, TAU);
+      context.fill();
+
+      context.save();
+      context.translate(cx, cy);
+      context.globalCompositeOperation = 'multiply';
+      PALETTE.forEach((color, index) => {
+        context.save();
+        context.rotate(phase * (index % 2 ? -1.25 : 1) + index * Math.PI / 4);
+        context.scale(1, 0.33 + index * 0.035);
+        context.strokeStyle = color;
+        context.globalAlpha = 0.52;
+        context.lineWidth = index === 3 ? 1.5 : 1;
+        context.shadowColor = color;
+        context.shadowBlur = 9;
+        context.beginPath();
+        context.arc(0, 0, radius * (0.78 + index * 0.12), 0, TAU);
+        context.stroke();
+        context.restore();
+      });
+      context.restore();
+
+      const projected = points.map(([x0, y0, z0, w0], index) => {
+        const xw = phase * 1.7 + pointerX;
+        const yz = phase * -1.15 + pointerY;
+        const xy = phase * 0.45;
+
+        let x = x0 * Math.cos(xw) - w0 * Math.sin(xw);
+        const w = x0 * Math.sin(xw) + w0 * Math.cos(xw);
+        let y = y0 * Math.cos(yz) - z0 * Math.sin(yz);
+        let z = y0 * Math.sin(yz) + z0 * Math.cos(yz);
+        const rotatedX = x * Math.cos(xy) - y * Math.sin(xy);
+        y = x * Math.sin(xy) + y * Math.cos(xy);
+        x = rotatedX;
+
+        const fourPerspective = 1.55 / (2.35 - w);
+        x *= fourPerspective;
+        y *= fourPerspective;
+        z *= fourPerspective;
+        const threePerspective = 1.7 / (2.55 - z);
+
+        return {
+          x: cx + x * radius * threePerspective,
+          y: cy + y * radius * threePerspective,
+          depth: threePerspective,
+          color: PALETTE[index % PALETTE.length],
+        };
+      });
+
+      context.globalCompositeOperation = 'multiply';
+      context.lineWidth = 0.45;
+      context.globalAlpha = 0.14;
+      for (let index = 0; index < projected.length; index += 4) {
+        const point = projected[index];
+        const next = projected[(index + 17) % projected.length];
+        context.strokeStyle = point.color;
+        context.beginPath();
+        context.moveTo(point.x, point.y);
+        context.lineTo(next.x, next.y);
+        context.stroke();
+      }
+
+      context.globalCompositeOperation = 'source-over';
+      projected
+        .sort((a, b) => a.depth - b.depth)
+        .forEach((point) => {
+          const size = Math.max(0.75, point.depth * 1.45);
+          context.globalAlpha = Math.min(0.92, 0.26 + point.depth * 0.32);
+          context.fillStyle = point.color;
+          context.shadowColor = point.color;
+          context.shadowBlur = size * 3.5;
+          context.beginPath();
+          context.arc(point.x, point.y, size, 0, TAU);
+          context.fill();
+        });
+
+      context.shadowBlur = 13;
+      context.globalAlpha = 0.92;
+      context.fillStyle = '#66733d';
+      context.beginPath();
+      context.arc(cx, cy, 3.2 + Math.sin(phase * 6) * 0.8, 0, TAU);
+      context.fill();
+      context.globalAlpha = 1;
+      context.shadowBlur = 0;
+
+      if (!reducedMotion.matches) {
+        const position = flight((time % 11000) / 11000, globalThis.innerWidth < 580);
+        stage.style.transform =
+          `translate(${position.x}px, ${position.y}px) rotate(${position.rotation}deg)`;
+        animationFrame = globalThis.requestAnimationFrame(draw);
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(stage);
+    stage.addEventListener('pointermove', move);
+    stage.addEventListener('pointerleave', leave);
+    resize();
+    draw(0);
+
+    return () => {
+      globalThis.cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+      stage.removeEventListener('pointermove', move);
+      stage.removeEventListener('pointerleave', leave);
+    };
+  }, []);
+
+  return (
+    <div class='quaternary-spheroid' ref={stageRef} aria-hidden='true'>
+      <canvas ref={canvasRef} />
+      <span class='spheroid-sigil'>IV</span>
+    </div>
+  );
+}

--- a/public/css/prolegomenon.css
+++ b/public/css/prolegomenon.css
@@ -1,0 +1,241 @@
+@font-face {
+  font-family: "Noto Serif";
+  src: url("/fonts/NotoSerif-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "League Spartan";
+  src: url("/fonts/LeagueSpartan-VF.woff2") format("woff2");
+  font-weight: 500 700;
+  font-display: swap;
+}
+
+:root {
+  --paper: #e8ddc5;
+  --paper-light: #f3ead8;
+  --ink: #171715;
+  --muted: #776f62;
+  --saffron: #d96512;
+  --cyan: #078f9a;
+  --rose: #a83b5b;
+  --indigo: #4d4b8b;
+  --olive: #66733d;
+  --ochre: #c17b22;
+  --verdigris: #188a82;
+  --rule: rgba(23, 23, 21, 0.34);
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: "Noto Serif", Georgia, "Times New Roman", serif;
+}
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10;
+  opacity: .18;
+  background-image:
+    repeating-radial-gradient(circle at 30% 40%, transparent 0 2px, rgba(65,48,26,.08) 3px 4px),
+    linear-gradient(90deg, rgba(255,255,255,.12), transparent 42%, rgba(61,42,18,.05));
+  background-size: 7px 7px, 100% 100%;
+  mix-blend-mode: multiply;
+}
+a { color: inherit; text-decoration: none; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
+
+.site-header {
+  height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 2.5vw;
+  padding: 0 .5vw;
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+  z-index: 2;
+}
+.wordmark { font-size: clamp(1.35rem, 2vw, 2rem); letter-spacing: -.04em; }
+nav { display: flex; gap: clamp(1.4rem, 3.5vw, 4rem); }
+nav a, .eyebrow, .enter, .folio, .movement-index, footer p, footer > a:last-child {
+  font-family: "League Spartan", Arial, Helvetica, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: .2em;
+}
+nav a { font-size: .69rem; font-weight: 600; }
+nav a:hover, nav a:focus-visible { color: var(--saffron); }
+
+.hero {
+  min-height: calc(100vh - 76px);
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, .75fr);
+  align-items: center;
+  gap: 6vw;
+  padding: 8vh 9vw 10vh 8vw;
+  border-bottom: 1px solid var(--rule);
+  overflow: hidden;
+}
+.hero-copy { max-width: 790px; animation: rise .75s cubic-bezier(.22,1,.36,1) both; }
+.hero-title {
+  max-width: 760px;
+  margin: 0;
+  font-size: clamp(2.45rem, 5vw, 5.5rem);
+  line-height: .98;
+  letter-spacing: -.045em;
+  text-wrap: balance;
+}
+.hero-datestamp {
+  max-width: 630px;
+  margin: clamp(1.6rem, 3vw, 2.8rem) 0 0;
+  color: var(--saffron);
+  font: 600 clamp(.6rem, .78vw, .76rem)/1.7 "League Spartan", Arial, sans-serif;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+.mathematical {
+  color: var(--rose);
+  font-family: "Noto Serif", Georgia, serif;
+  font-size: 1.15em;
+  font-style: italic;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: none;
+  white-space: nowrap;
+}
+.mathematical sup { font-size: .62em; vertical-align: super; }
+.eyebrow { margin: clamp(2.5rem, 5vw, 4.5rem) 0 1.2rem; font-size: clamp(.58rem, .72vw, .68rem); font-weight: 700; color: var(--saffron); }
+.incipit { max-width: 680px; margin: 0; font-size: clamp(1.7rem, 2.75vw, 3rem); line-height: 1.18; letter-spacing: -.025em; }
+.drop-cap {
+  float: left;
+  color: var(--ink);
+  font-size: 3.75em;
+  line-height: .73;
+  margin: .1em .13em 0 0;
+  padding: .08em .1em .03em;
+  border: 1px solid var(--saffron);
+  box-shadow: inset 0 0 0 4px var(--paper), inset 0 0 0 5px rgba(23,23,21,.42);
+  text-shadow: 2px 2px 0 rgba(217,101,18,.18);
+}
+.enter { display: inline-flex; align-items: center; gap: 1rem; margin-top: 3rem; color: var(--saffron); font-size: .7rem; font-weight: 700; }
+.enter > span { display: block; width: 76px; height: 1px; background: var(--saffron); transition: width .25s ease; }
+.enter b { font-size: 1.25rem; font-weight: 400; }
+.enter:hover > span, .enter:focus-visible > span { width: 100px; }
+.enter:focus-visible { outline: 2px solid var(--cyan); outline-offset: 8px; }
+
+.geometry { position: relative; width: min(27vw, 360px); aspect-ratio: 1 / 1.15; justify-self: end; animation: draw-in 1s .2s both; }
+.axis, .measure, .curve { position: absolute; display: block; }
+.axis-desire { left: 22%; right: 1%; top: 52%; height: 1.5px; background: var(--rose); }
+.axis-habit { top: 5%; bottom: 2%; left: 55%; width: 1.5px; background: var(--indigo); }
+.curve { width: 63%; height: 64%; left: 0; top: 12%; border-right: 1.5px solid var(--olive); border-bottom: 1.5px solid var(--olive); border-radius: 0 0 100% 0; transform: skew(-8deg); }
+.intersection { position: absolute; left: calc(55% - 5px); top: calc(52% - 5px); width: 11px; height: 11px; border: 2px solid var(--cyan); border-radius: 50%; background: var(--paper); box-shadow: 0 0 0 5px rgba(7,143,154,.1); }
+.measure-one { left: 6%; top: 29%; width: 43%; height: 1.5px; background: var(--ochre); }
+.measure-two { left: 34%; right: 4%; top: 76%; height: 1.5px; background: var(--verdigris); }
+.geometry-label { position: absolute; font-family: "League Spartan", Arial, sans-serif; font-size: .63rem; letter-spacing: .16em; font-style: italic; color: var(--muted); background: var(--paper); padding: .25rem .4rem; }
+.geometry-label i { display: inline-block; width: 12px; height: 4px; margin-right: .45rem; border-radius: 999px; vertical-align: .08em; }
+.label-desire { top: calc(52% - 2rem); right: 0; color: var(--rose); }
+.label-desire i { background: var(--rose); }
+.label-habit { top: 5%; left: calc(55% + .5rem); color: var(--indigo); writing-mode: vertical-rl; }
+.label-habit i { width: 4px; height: 12px; margin: 0 0 .45rem; background: var(--indigo); }
+
+.quaternary-spheroid {
+  position: absolute;
+  right: 7.2vw;
+  bottom: 3.4vh;
+  width: 178px;
+  height: 178px;
+  opacity: .9;
+  transform: rotate(-8deg);
+  cursor: crosshair;
+  touch-action: none;
+  will-change: transform;
+  filter: saturate(1.12);
+  animation: spheroid-enter 1.15s .55s both;
+}
+.quaternary-spheroid canvas { display: block; width: 100%; height: 100%; }
+.spheroid-sigil { position: absolute; right: .2rem; bottom: .1rem; font: 600 .55rem/1 "League Spartan", Arial, sans-serif; letter-spacing: .18em; color: var(--rose); text-shadow: 0 0 8px rgba(168,59,91,.28); }
+.folio { position: absolute; right: 2.9vw; top: 6%; bottom: 6%; display: flex; flex-direction: column; align-items: center; justify-content: space-between; padding-left: 1.25rem; border-left: 1px solid var(--rule); font-size: .6rem; }
+.folio > span { writing-mode: vertical-rl; }
+.folio i { width: 5px; height: 5px; border-radius: 50%; background: var(--saffron); }
+.folio b { font-weight: 400; line-height: 2.2; text-align: center; }
+
+.sequence { background: var(--paper-light); }
+.epigraph {
+  width: min(790px, 84vw);
+  margin: 0 auto;
+  padding: clamp(5rem, 10vw, 9rem) 0 clamp(1rem, 3vw, 3rem);
+  color: #362f28;
+}
+.epigraph h2 { margin: 0 0 clamp(2.5rem, 5vw, 4.5rem); color: var(--ink); font-size: clamp(2.8rem, 6vw, 5.8rem); font-weight: 400; letter-spacing: -.045em; line-height: 1; }
+.epigraph blockquote { margin: 0; }
+.epigraph blockquote p { margin: 0 0 1.5em; font-size: clamp(1.25rem, 2.2vw, 2rem); line-height: 1.6; font-style: italic; }
+.epigraph figcaption { margin-top: 2rem; font: 600 .64rem/1.4 "League Spartan", Arial, sans-serif; letter-spacing: .2em; text-transform: uppercase; color: var(--saffron); }
+.movement { width: min(1040px, 84vw); margin: 0 auto; padding: clamp(5rem, 10vw, 9rem) 0 0; }
+.movement p { width: min(790px, 100%); margin: 0 auto; font-size: clamp(1.3rem, 2.1vw, 1.95rem); line-height: 1.75; text-wrap: pretty; }
+.movement p::first-line { color: #362f28; }
+.prose-paragraph { display: block; }
+.movement-copy { display: contents; }
+.prose-paragraph + .prose-paragraph { margin-top: 1.45em; }
+.first-movement .prose-paragraph:first-child::first-letter { float: left; font-size: 5.7em; line-height: .67; padding: .12em .11em 0 0; color: var(--saffron); }
+.paragraph-break { display: block; height: 1.5em; }
+.question, .answer { display: block; }
+.inline-quotation { font-style: italic; color: #4f473d; }
+.question { font-style: italic; color: var(--muted); }
+.answer { margin-top: .2em; font-size: 1.15em; color: var(--rose); }
+.movement-index { display: flex; align-items: center; gap: 1rem; margin-bottom: 2.2rem; font-size: .62rem; color: var(--muted); }
+.movement-index i { width: 74px; height: 1px; background: var(--rule); }
+.section-break { display: flex; align-items: center; justify-content: center; gap: 1.5rem; padding: clamp(4rem, 8vw, 7rem) 0 0; color: var(--saffron); }
+.section-break i { display: block; width: min(170px, 23vw); height: 1px; background: var(--rule); }
+.section-break span { font-size: .85rem; }
+.movement:last-of-type { padding-bottom: clamp(4rem, 8vw, 7rem); }
+
+.begin-questionnaire { width: min(1040px, 84vw); margin: 0 auto; padding: clamp(4rem, 8vw, 7rem) 0 clamp(6rem, 12vw, 11rem); border-top: 1px solid var(--rule); text-align: center; }
+.begin-questionnaire p { margin: 0 0 1.5rem; color: var(--muted); font-size: 1rem; font-style: italic; }
+.begin-questionnaire a { display: inline-block; padding: 1rem 1.3rem .8rem; border: 1px solid var(--saffron); color: var(--saffron); font: 700 .7rem/1 "League Spartan", Arial, sans-serif; letter-spacing: .18em; text-transform: uppercase; }
+.begin-questionnaire a:hover, .begin-questionnaire a:focus-visible { background: var(--saffron); color: var(--paper-light); }
+
+footer { min-height: 260px; background: var(--ink); color: var(--paper); padding: 4rem 6vw; display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: end; gap: 2rem; }
+footer p { margin: 0; font-size: .58rem; text-align: center; color: #bfb5a4; }
+footer > a:last-child { font-size: .58rem; text-align: right; color: #dca064; }
+
+@keyframes rise { from { opacity: 0; transform: translateY(24px); } }
+@keyframes draw-in { from { opacity: 0; transform: scale(.96); } }
+@keyframes spheroid-enter { from { opacity: 0; transform: translateY(12px) rotate(-8deg) scale(.92); } }
+
+@media (max-width: 900px) {
+  .site-header { height: 68px; }
+  nav a:not(:first-child) { display: none; }
+  .hero { min-height: calc(100svh - 68px); display: block; padding: 13vh 8vw 10vh; }
+  .hero-copy { max-width: 650px; }
+  .geometry { width: 260px; margin: 8vh 0 0 auto; opacity: .82; }
+  .quaternary-spheroid { right: 7vw; bottom: 2.5vh; width: 144px; height: 144px; transform-origin: bottom right; }
+  .folio { display: none; }
+  footer { grid-template-columns: 1fr; align-items: start; }
+  footer p, footer > a:last-child { text-align: left; }
+}
+
+@media (max-width: 580px) {
+  .wordmark { font-size: 1.2rem; }
+  nav { display: none; }
+  .hero { padding: 10vh 7vw 8vh; }
+  .hero-title { font-size: clamp(2.3rem, 12vw, 3.45rem); }
+  .incipit { font-size: clamp(1.65rem, 8vw, 2.5rem); }
+  .drop-cap { font-size: 3em; }
+  .enter { margin-top: 3rem; }
+  .geometry { width: 220px; }
+  .quaternary-spheroid { position: relative; right: auto; bottom: auto; width: 132px; height: 132px; margin: -4.5rem 0 1rem auto; }
+  .movement { width: 86vw; }
+  .movement p { font-size: 1.22rem; line-height: 1.68; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,12 +1,5 @@
-/**
- * Index Route - Landing Page
- *
- * GET /
- *
- * Full landing page with hero, philosophy section, and gate preview.
- */
-
 import { Handlers } from '$fresh/server.ts';
+import QuaternarySpheroid from '../islands/QuaternarySpheroid.tsx';
 
 export const handler: Handlers = {
   GET(_req, ctx) {
@@ -14,157 +7,281 @@ export const handler: Handlers = {
   },
 };
 
+const movements = [
+  <span class='movement-copy' key='01'>
+    <span class='prose-paragraph'>
+      The site aformulationoftruth.com serves a sequence of prompts. Call them questions, or
+      invitations to pause.
+    </span>
+    <span class='prose-paragraph'>
+      And in that moment what wells up within beckons to you, a user of language, to translate from
+      this engram a past encoded as living memory in the present as response—as a response you
+      compose to a question. Translated memories, stored perhaps as engrams in a mind whose
+      holographic store might be likened to the most advanced synthesizer of pharmacopia in the
+      universe. As Proust writes,{' '}
+      <q class='inline-quotation'>
+        Memory is a sort of pharmacy-laboratory in which chance sometimes makes a soothing drug and
+        sometimes a dangerous poison.
+      </q>
+    </span>
+    <span class='prose-paragraph'>
+      Sometimes those fragments congeal into something that coheres; other fragments remain…well,
+      fragmented, partial. In fact, defiant in how unbothered to be coherent some of the fragments
+      may be.
+    </span>
+    <span class='prose-paragraph'>
+      These sketches in word bear little or no meaning to any reader beyond the writer who
+      translated from their own recollection of a past in reflex response to a prompt. A question:
+    </span>
+    <span class='paragraph-break' />
+    <span class='question'>Who or what is your greatest love?</span>
+    <span class='answer'>Big dick Tony.</span>
+    <span class='paragraph-break' />
+    This being an example. It&apos;s a fragment. We&apos;re sure BDT is lovely, but we know
+    precisely one thing about him. And that is a fragment. Not a whole. Trust
+  </span>,
+  <span class='movement-copy' key='02'>
+    Almost a decade ago in response to <em>what is your idea of perfect happiness</em>{' '}
+    I composed “a healthy suspicion of both/and; an imperfect understanding of either/or.” Through
+    the ensuing decade, far from becoming more certain of precisely what meaning that aphoristic,
+    grammatically symmetric phrase distills I remain enamored of the string&apos;s valence. To the
+    first question of the Proust questionnaire ego aquired immunity and I remained attached to the
+    formulation. Maybe its accidental depth, its boss grammatical construction? Perhaps its mystical
+    resonance plucks a chord I&apos;ve yet to learn how to name.
+  </span>,
+  <span class='movement-copy' key='03'>
+    We humans understand ourselves—and don&apos;t—a great degree through word. Social-linguistic
+    beings we are through and through! And when upon a mellifluous or otherwise erudite sounding
+    phonic chain no less its own creation the ego fastens with a temerity I tether my
+    self-understanding to and perform. Uncertain though we are certain concepts&apos; consequence.
+    Nonetheless, we parrot with certainty these rote phrases that over and over bamboozle us from
+    the beginning!
+  </span>,
+  <span class='movement-copy' key='04'>
+    The saints and sages whose devotion to wisdom traditions and contemplative Christian or
+    Buddhist, etc. lifestyles instruct aspirants to discipline the body-mind as means to alter
+    consciousness. So refined or perfected that conscious our own awareness we may untie this knot
+    to word… even if only for 30 seconds. Ever faithful one&apos;s ego to its action to possess the
+    egoic, self-centered concopis, to wit, there to reattach a limited, self-centric I almost as
+    soon as our mind ascertains the 🍝bility that another way{' '}
+    <em>exists</em>. That knowledge alone, in this crackhead&apos;s experience, is not going to
+    conderier it
+    <span class='paragraph-break' />
+    bestow upon the sādhika a clean break from all those aasanas so very human and childlike in
+    nature.
+  </span>,
+  <span class='movement-copy' key='05'>
+    Ramana Maharshi directs disciples to eliminate the first-person possessive from their speech.
+    That is, don’t use ‘my’. It’s remarkable how challenging that practice can be! For over half
+    this life I’ve lived, I seek to neuter at its source in language the tendency of humans to
+    ‘mine’. But gosh is it ever But equally true and fit for the task of speaking about any
+    situation the possessive may be appealed to is the first-person I. Any my statement can be
+    reformulated with the absence of explicit grammatical possessive
+  </span>,
+  <span class='movement-copy' key='06'>
+    So the responses that I gave to these questions, what emerged at 20 years-old in Greeley,
+    Colorado and the responses I gave at 32 in Fort Lauderdale, Florida sitting in a chair near to
+    aged and eating Granne devouring a chicken-salad sandwich I’d made her for lunch bore such a
+    difference that I viscerally recognized two selves within one body’s lifetime both narrated as a
+    coherent and continuous series of events by the ego I, Ralph/ie, heretofore subjected to
+    sustained virtuous sādhana in measure far less frequently than I, Ralph/ie untethe
+  </span>,
+  <span class='movement-copy' key='07'>
+    And so the site is served that we may become comfortable as actors with changes, radical
+    disruptions.
+  </span>,
+  <span class='movement-copy' key='08'>
+    We write whilst the President of the United States insists he aurally rape us subjects daily.
+    The reality we Americans live in under DJT&apos;s suzerainty is one saturated with falsehood,
+    whereby the president repeats over and over baseless bile to dull the faculty by which people
+    recognize truth. Capital in this country [shit in a] Diaper Don thinks is him—read that again I
+    wrote it correctly—he and each of the cabinet members place above all else. The ink parlor I
+    live above hangs a sign prominently stating: Cash is king. In American politics only because
+    Diarrhea Diaper Don president can Cash be king. But I digress…
+  </span>,
+  <span class='movement-copy' key='09'>
+    This feeble administration enables the wealthy to purchase influence &amp; shape policy more
+    than any and every legitimate administration prior to its metastasis. The overreach into daily
+    lives of us Americans big tech—Facebook, Amazon, Apple, Microsoft, etc—enable an influence over
+    what a people can imagine to be possible in a manner unprecedented. .: no appeal to history to
+    help us here and the temptation is to believe that history that society &amp; culture has
+    irredeemably crested at its nadir. This is not false. True enough billionaires like Bezos
+    family, like Musk harem, and that twat Zuck whatever the hell he does in HI will be taxed out of
+    existence. They will be made into hundred millionaires or we will imprison them. And if they
+    attempt to flee the earth, we&apos;ll not allow them to land or resupply.
+  </span>,
+  <span class='movement-copy' key='10'>
+    People of the United States of America: As certain as Presidents do die our nation—we forgot who
+    we are. Having worked so hard and finally able to rest after fleecing American workers. Diahrrea
+    Don and these obscenely wealthy billionaires are to become a footnote that record approximately
+    where at an unmarked grave. We forgot, Americans, who we are. And in forgetting we get what we
+    choose. Broken families, frayed relations, expenses higher than one&apos;s job(s) pays. These
+    aspirations are those due the subjects of a rapist president of the United States. A loser. A
+    narcissist who, without shame, insists upon aurally fucking our consciousness with his word
+    alone. Drowning out fertile, creative, rebellious American word he who Dumps Daily in Diapers
+    Don (think explosive diahrhea) aims to scar a majority of American&apos;s conscious awareness of
+    what is true. Focused only on self-aggrandizement, Diaper Don is the first president that seeks
+    for a majority of his subjects to be broken. Like a cowboy his horse, the Diaper Don seeks to
+    break what was once our moral fabric founded upon ideas and ideals for the benefit of himself,
+    the leader of a wealthy billionaire class. But today is not yet the time to focus either on
+    these hard truths, or on the monumental stupidity those our compatriots who cast their vote for
+    such a scoundrel foist upon us who, meeting a bare minimum, listen to what a candidate says. Now
+    as president that former candidate without grace is dying slowly in front of us, entering his
+    own hell. And once that body so full of shit and lies croaks, we will rebuild. Not with Bezos or
+    Musk or Zuck but certainly, in large part, from their monies. And other billionaires whose
+    fortunes will fund the working-class renaissance of America. When a single Black mother of two
+    can get on a stage to thank a movement that finally, after over 250 years, removed the white
+    racists foot from her neck. As nations forget, so too we may remember…
+  </span>,
+  <span class='movement-copy' key='11'>
+    And the task of this work is to cultivate the habits of attention. Without attention no
+    cultural-political renewal can endure. A society—peoplew— incapable of examining themselves
+    cannot (clearly can&apos;t!) govern itself. The same may be said of a person. Should renewal
+    come it will arrive because you and I and ordinary folks across the most beautiful geography on
+    planet earth, on its westward spin the pinnacle of civilization will learn again how to
+    distinguish truth from performance, possession from custodianship, and certainty from wisdom.
+  </span>,
+  <span class='movement-copy' key='12'>
+    Perhaps then a mother, exhausted by years of carrying more than any one person ought to bear,
+    may stand before her children and discover that history has become a little less heavy upon
+    their shoulders than it was upon her own.
+  </span>,
+];
+
+function Geometry() {
+  return (
+    <div class='geometry' aria-label='Desire intersecting with habit'>
+      <span class='axis axis-desire' aria-hidden='true' />
+      <span class='axis axis-habit' aria-hidden='true' />
+      <span class='curve' />
+      <span class='intersection' />
+      <span class='geometry-label label-desire'>
+        <i />desire
+      </span>
+      <span class='geometry-label label-habit'>
+        <i />habit
+      </span>
+      <span class='measure measure-one' />
+      <span class='measure measure-two' />
+    </div>
+  );
+}
+
 export default function Home() {
   return (
-    <html lang="en">
+    <html lang='en'>
       <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>a formulation of truth</title>
-        <meta name="description" content="An apparatus for attention. Self-inquiry through the Proust Questionnaire." />
-        <link rel="stylesheet" href="/css/main.css" />
+        <meta charset='UTF-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        <title>Prolegomenon | a4முளसत्यsya</title>
+        <meta
+          name='description'
+          content='Some thoughts prior to the main sequence, a Proust questionnaire.'
+        />
+        <link rel='stylesheet' href='/css/prolegomenon.css' />
       </head>
       <body>
-        <nav>
-          <a href="/" class="logo">A4T</a>
-          <div class="nav-links">
-            <a href="/about.html">About</a>
-            <a href="/contact.html">Contact</a>
-          </div>
-        </nav>
-
         <main>
-          <section class="hero">
-            <div class="hero-content">
-              <p class="tagline">An apparatus for attention</p>
-              <h1 class="title">
-                a formulation
-                <span>of truth</span>
-              </h1>
-              <p class="subtitle">
-                You are not one self. This is not a tragedy.
-                It is more like the weather.
+          <header class='site-header'>
+            <a class='wordmark' href='#top' aria-label='A formulation of truth'>
+              a4<span lang='ta'>முள</span>
+              <span lang='sa'>सत्य</span>sya
+            </a>
+            <nav aria-label='Primary navigation'>
+              <a href='#prolegomenon'>Text</a>
+              <a href='#sequence'>Sequence</a>
+              <a href='/questions'>Questions</a>
+            </nav>
+          </header>
+
+          <section class='hero' id='top' aria-labelledby='prolegomenon'>
+            <div class='hero-copy'>
+              <p class='hero-title'>
+                Some thoughts prior to the main sequence, a Proust questionnaire.
               </p>
-              <div class="cta-group">
-                <a href="/gate" class="cta cta-primary">Begin Inquiry</a>
-                <a href="/about.html" class="cta">Learn More</a>
-              </div>
+              <p class='hero-datestamp'>
+                Inscribed in the{' '}
+                <span class='mathematical'>
+                  4<sup>y</sup>-dimensional
+                </span>{' '}
+                common Earth-time characteristic of this planet: summer, Common Era 2026, in the
+                reign of Pope Leo XIV.
+              </p>
+              <p class='eyebrow' id='prolegomenon'>PROLEGOMENON:</p>
+              <p class='incipit'>
+                <span class='drop-cap' aria-hidden='true'>T</span>
+                <span class='sr-only'>T</span>he site serves a sequence of prompts. Call them
+                questions, or invitations to pause.
+              </p>
+              <a class='enter' href='#sequence'>
+                <span aria-hidden='true' /> continue reading <b aria-hidden='true'>→</b>
+              </a>
             </div>
-            <div class="scroll-indicator">
-              <span></span>
-            </div>
+            <Geometry />
+            <QuaternarySpheroid />
+            <aside class='folio' aria-hidden='true'>
+              <span>I · TEXT</span>
+              <i />{' '}
+              <b>
+                01<br />
+                {String(movements.length).padStart(2, '0')}
+              </b>
+            </aside>
           </section>
 
-          <section class="section">
-            <div class="section-inner">
-              <span class="section-label">Philosophy</span>
-              <h2 class="section-title">The questionnaire as mirror</h2>
-              <p class="section-text">
-                The Proust Questionnaire is not a test and not a profile.
-                It is a mechanic for making the past legible in the present.
-                <em>A selfie taken from within.</em>
-              </p>
-              <p class="section-text">
-                Answer. Forget your responses. Wait. The site enforces waiting.
-                We'll notify with an email or a telegram message if you'd prefer.
-                The mechanic works to the degree we don't perform but as
-                subtly powerful users of language translate the memory any one question may conjure.
-                Delight therein or maybe struggle a bit to capture wisely with word this artifact.
-                Truth resides in the reconstruction those events without precedent in our world,
-                where nothing ever repeats itself exactly.
-              </p>
-
-              <div class="quote-block">
+          <article class='sequence' id='sequence'>
+            <figure class='epigraph'>
+              <h2>The Knot</h2>
+              <blockquote>
                 <p>
-                  "We say that the hour of death cannot be forecast, but when we say this
-                  we imagine that hour as placed in an obscure and distant future."
+                  The rainbow shines, but only in the thought<br />
+                  of him that looks, yet not in that alone<br />
+                  for who makes rainbows by invention?
                 </p>
-                <cite>Marcel Proust</cite>
-              </div>
-            </div>
-          </section>
+                <p>
+                  And there were many standing round a waterfall<br />
+                  Who saw one bow each yet not the same to all.<br />
+                  For each a hand&apos;s breadth further than the next<br />
+                  The sun on falling waters writes the text.<br />
+                  Which yet is in the eye, or in the thought.
+                </p>
+                <p>It was a hard thing to undo this knot.</p>
+              </blockquote>
+              <figcaption>—Gerard Manley Hopkins</figcaption>
+            </figure>
 
-          <section id="begin" class="section gate-section">
-            <div class="gate-content">
-              <div class="gate-icon">?</div>
-              <h2 class="gate-title">What is your idea of perfect happiness?</h2>
-              <p class="gate-description">
-                These are not polite questions. They are holes in the ice.
-                If you answer them honestly, something cold touches your feet.
-              </p>
-
-              <form action="/gate" method="GET" class="gate-form">
-                <div class="form-group">
-                  <label for="answer">Your reflection</label>
-                  <div class="textarea-wrapper">
-                    <div class="watermark">truth</div>
-                    <textarea
-                      id="answer"
-                      name="preview"
-                      placeholder="Take your time..."
-                      aria-describedby="accessibility-hint"
-                    ></textarea>
-                  </div>
-                  <p class="accessibility-note" id="accessibility-hint">
-                    For voice input, use <a href="https://github.com/cjpais/Handy" target="_blank" rel="noopener">Handy</a> - free offline speech-to-text
-                  </p>
+            {movements.map((movement, index) => (
+              <section class={`movement movement-${index + 1}`} key={index}>
+                <div class='movement-index' aria-hidden='true'>
+                  <span>{String(index + 1).padStart(2, '0')}</span>
+                  <i />
                 </div>
-                <button type="submit" class="cta cta-primary" style="width: 100%;">
-                  Continue
-                </button>
-              </form>
-            </div>
-          </section>
+                <p class={index === 0 ? 'first-movement' : ''}>{movement}</p>
+                {index < movements.length - 1 && (
+                  <div class='section-break' aria-hidden='true'>
+                    <i />
+                    <span>✦</span>
+                    <i />
+                  </div>
+                )}
+              </section>
+            ))}
+
+            <section class='begin-questionnaire'>
+              <p>The main sequence awaits.</p>
+              <a href='/gate'>Begin the questionnaire →</a>
+            </section>
+          </article>
+
+          <footer id='about'>
+            <a class='wordmark' href='#top'>
+              a4<span lang='ta'>முள</span>
+              <span lang='sa'>सत्य</span>sya
+            </a>
+            <p>A sequence for becoming acquainted with one self.</p>
+            <a href='#top'>Return to the beginning ↑</a>
+          </footer>
         </main>
-
-        <footer>
-          <div class="footer-inner">
-            <div class="footer-links">
-              <a href="/about.html">About</a>
-              <a href="/contact.html">Contact</a>
-              <a href="/privacy.html">Privacy</a>
-            </div>
-            <p class="footer-copy">
-              Encrypted database hosted in Iceland by <a href="https://fobdongle.com" target="_blank" rel="noopener" style="color: var(--neon-emerald); text-decoration: none;">FlokiNET</a>
-            </p>
-          </div>
-        </footer>
-
-        <script>{`
-          // Smooth scroll for anchor links
-          document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-            anchor.addEventListener('click', function(e) {
-              e.preventDefault();
-              const target = document.querySelector(this.getAttribute('href'));
-              if (target) {
-                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
-              }
-            });
-          });
-
-          // Intersection Observer for scroll animations
-          const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
-          };
-
-          const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-              if (entry.isIntersecting) {
-                entry.target.style.opacity = '1';
-                entry.target.style.transform = 'translateY(0)';
-              }
-            });
-          }, observerOptions);
-
-          // Observe sections
-          document.querySelectorAll('.section-inner, .gate-content').forEach(el => {
-            el.style.opacity = '0';
-            el.style.transform = 'translateY(30px)';
-            el.style.transition = 'opacity 0.8s ease, transform 0.8s ease';
-            observer.observe(el);
-          });
-        `}</script>
       </body>
     </html>
   );

--- a/routes/questions.tsx
+++ b/routes/questions.tsx
@@ -1,0 +1,7 @@
+import { Handlers } from '$fresh/server.ts';
+
+export const handler: Handlers = {
+  GET(req) {
+    return Response.redirect(new URL('/questions.html', req.url), 307);
+  },
+};


### PR DESCRIPTION
## What changed

- Replaces the root Deno Fresh landing route with the Prolegomenon design and complete prose.
- Adds the interactive JavaScript 4D spheroid as a Fresh island.
- Adds the dedicated landing-page stylesheet.
- Restores `/questions` through the existing static question list.
- Keeps `/gate` as the questionnaire entry point.

## Why

Moves the validated standalone landing page into the maintained Deno runtime in this repository so it can be reviewed and deployed with the application.

## Validation

- `deno fmt --check` passed for the changed TypeScript and TSX files.
- `deno lint` passed for the changed TypeScript and TSX files.
- Offline esbuild parsing passed for the route and island.
- `git diff --check` passed.
- Full `deno check` was attempted, but this environment could not reach `esm.sh` or `deno.land` to fetch dependencies.

## Scope note

The unrelated local `public/pgp-key.asc` filesystem artifact is intentionally excluded.