### PR TITLE
Add no-auth POST /api/commissions for browser-encrypted messages

### DIFF
--- a/migrations/0004_add_commissions.sql
+++ b/migrations/0004_add_commissions.sql
@@ -1,0 +1,28 @@
+-- Migration: Add commissions table
+-- First-contact commission requests submitted to POST /api/commissions
+-- (typically from external sites like fobdongle.com/commission.html).
+--
+-- Design:
+--   * The sender's browser encrypts client-side; the server stores
+--     `ciphertext` verbatim and never sees plaintext.
+--   * `algorithm` is a client-supplied label (e.g.
+--     'rsa-oaep-sha256+aes-256-gcm', 'age-x25519') so the operator's
+--     offline decrypt tool knows how to interpret the blob.
+--   * No sender identity is captured server-side. If the sender wants to
+--     include contact info, they put it inside the encrypted body.
+
+CREATE TABLE IF NOT EXISTS commissions (
+  id VARCHAR PRIMARY KEY DEFAULT gen_random_uuid(),
+  algorithm VARCHAR(64) NOT NULL,
+  ciphertext TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW() NOT NULL,
+  delivered_at TIMESTAMP
+);
+
+-- Speeds up the offline pipeline's "give me everything undelivered" query.
+CREATE INDEX IF NOT EXISTS idx_commissions_undelivered
+  ON commissions (created_at)
+  WHERE delivered_at IS NULL;
+
+COMMENT ON COLUMN commissions.algorithm IS 'Client-supplied crypto label for the ciphertext (e.g. rsa-oaep-sha256+aes-256-gcm, age-x25519). Operator uses this to select the right decrypt tool.';
+COMMENT ON COLUMN commissions.ciphertext IS 'Opaque browser-encrypted payload. Stored verbatim; server never decrypts.';

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -75,6 +75,16 @@ let authLimiter = createRateLimiter({
   prefix: 'rl:auth:',
 });
 
+// Rate limit for the no-auth POST /api/commissions endpoint. Tighter than
+// the general limiter because the endpoint is open to the internet and
+// there is no login wall in front of it.
+export let commissionsLimiter = createRateLimiter({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  message: 'Too many commission submissions. Please try again later.',
+  prefix: 'rl:commissions:',
+});
+
 // CORS configuration
 const corsOptions: cors.CorsOptions = {
   origin: function (origin, callback) {
@@ -83,10 +93,13 @@ const corsOptions: cors.CorsOptions = {
     
     const allowedOrigins = [
       'http://localhost:3000',
-      'http://localhost:5000', 
+      'http://localhost:5000',
       'https://aformulationoftruth.com',
       'https://proust.aformulationoftruth.com',
-      /\.aformulationoftruth\.com$/
+      /\.aformulationoftruth\.com$/,
+      // fobdongle.com/commission.html POSTs to /api/commissions cross-origin.
+      'https://fobdongle.com',
+      'https://www.fobdongle.com'
     ];
     
     const isAllowed = allowedOrigins.some(allowedOrigin => {
@@ -173,6 +186,18 @@ export async function setupSecurity(app: Express) {
       store: new RedisStore({
         sendCommand: (...args: string[]) => client.sendCommand(args),
         prefix: 'rl:auth:',
+      }),
+    });
+
+    commissionsLimiter = rateLimit({
+      windowMs: 60 * 60 * 1000,
+      max: 5,
+      message: { error: 'Too many commission submissions. Please try again later.' },
+      standardHeaders: true,
+      legacyHeaders: false,
+      store: new RedisStore({
+        sendCommand: (...args: string[]) => client.sendCommand(args),
+        prefix: 'rl:commissions:',
       }),
     });
 

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -96,10 +96,7 @@ const corsOptions: cors.CorsOptions = {
       'http://localhost:5000',
       'https://aformulationoftruth.com',
       'https://proust.aformulationoftruth.com',
-      /\.aformulationoftruth\.com$/,
-      // fobdongle.com/commission.html POSTs to /api/commissions cross-origin.
-      'https://fobdongle.com',
-      'https://www.fobdongle.com'
+      /\.aformulationoftruth\.com$/
     ];
     
     const isAllowed = allowedOrigins.some(allowedOrigin => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import { createServer, type Server } from "http";
 import cors from "cors";
 import { storage } from "./storage";
 import { z } from "zod";
-import { insertResponseSchema, insertGateResponseSchema } from "@shared/schema";
+import { insertResponseSchema, insertGateResponseSchema, insertCommissionSchema } from "@shared/schema";
 import { setupAuth, isAuthenticated } from "./auth";
 import { commissionsLimiter } from "./middleware/security";
 
@@ -573,10 +573,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.options("/api/commissions", commissionsCors);
   app.post("/api/commissions", commissionsCors, commissionsLimiter, async (req, res) => {
     try {
-      const parsed = z.object({
-        algorithm: z.string().min(1),
-        ciphertext: z.string().min(1),
-      }).parse(req.body);
+      const parsedResult = insertCommissionSchema.safeParse(req.body);
+      if (
+        !parsedResult.success ||
+        typeof parsedResult.data.algorithm !== "string" ||
+        typeof parsedResult.data.ciphertext !== "string" ||
+        parsedResult.data.algorithm.length === 0 ||
+        parsedResult.data.ciphertext.length === 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          error: "algorithm and ciphertext are required",
+        });
+      }
+
+      const parsed = parsedResult.data;
       if (parsed.ciphertext.length > 100_000 || parsed.algorithm.length > 64) {
         return res.status(400).json({
           success: false,
@@ -588,12 +599,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
       console.log(`[commissions] stored (id=${row.id})`);
       res.json({ success: true, message: "Commission received.", id: row.id });
     } catch (error) {
-      if (error instanceof z.ZodError) {
-        return res.status(400).json({
-          success: false,
-          error: "algorithm and ciphertext are required",
-        });
-      }
       console.error(
         "[commissions] insert failed:",
         error instanceof Error ? error.name : "Unknown"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -574,13 +574,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/commissions", commissionsCors, commissionsLimiter, async (req, res) => {
     try {
       const parsedResult = insertCommissionSchema.safeParse(req.body);
-      if (
-        !parsedResult.success ||
-        typeof parsedResult.data.algorithm !== "string" ||
-        typeof parsedResult.data.ciphertext !== "string" ||
-        parsedResult.data.algorithm.length === 0 ||
-        parsedResult.data.ciphertext.length === 0
-      ) {
+      if (!parsedResult.success) {
         return res.status(400).json({
           success: false,
           error: "algorithm and ciphertext are required",
@@ -588,6 +582,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const parsed = parsedResult.data;
+      if (
+        typeof parsed.algorithm !== "string" ||
+        typeof parsed.ciphertext !== "string" ||
+        parsed.algorithm.length === 0 ||
+        parsed.ciphertext.length === 0
+      ) {
+        return res.status(400).json({
+          success: false,
+          error: "algorithm and ciphertext are required",
+        });
+      }
       if (parsed.ciphertext.length > 100_000 || parsed.algorithm.length > 64) {
         return res.status(400).json({
           success: false,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,8 +2,9 @@ import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { z } from "zod";
-import { insertResponseSchema, insertGateResponseSchema } from "@shared/schema";
+import { insertResponseSchema, insertGateResponseSchema, insertCommissionSchema } from "@shared/schema";
 import { setupAuth, isAuthenticated } from "./auth";
+import { commissionsLimiter } from "./middleware/security";
 
 // Admin authentication middleware
 const isAdmin = async (req: any, res: any, next: any) => {
@@ -550,6 +551,47 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post("/api/newsletter/signup", handleNewsletterSignup);
   app.post("/api/newsletter/subscribe", handleNewsletterSignup);
+
+  // Commissions - opaque browser-encrypted first-contact messages.
+  //
+  // The sender's browser encrypts client-side (e.g. via
+  // fobdongle.com/commission.html's RSA-OAEP+AES-GCM hybrid). The server
+  // never sees plaintext, never decrypts, and captures no sender identity.
+  // The operator decrypts offline using whatever private key matches the
+  // client-supplied `algorithm` label.
+  //
+  // No auth wall (commissions are first-contact). Access is IP-rate-limited
+  // (see commissionsLimiter in middleware/security.ts).
+  app.post("/api/commissions", commissionsLimiter, async (req, res) => {
+    try {
+      const parsed = insertCommissionSchema.parse(req.body);
+      if (parsed.ciphertext.length > 200_000 || parsed.algorithm.length > 64) {
+        return res.status(400).json({
+          success: false,
+          error: "Payload too large",
+        });
+      }
+
+      const row = await storage.createCommission(parsed);
+      console.log(`[commissions] stored (alg=${parsed.algorithm})`);
+      res.json({ success: true, message: "Commission received.", id: row.id });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({
+          success: false,
+          error: "algorithm and ciphertext are required",
+        });
+      }
+      console.error(
+        "[commissions] insert failed:",
+        error instanceof Error ? error.name : "Unknown"
+      );
+      res.status(500).json({
+        success: false,
+        error: "Failed to process commission",
+      });
+    }
+  });
 
   // Admin routes (temporarily disabled - storage methods need implementation)
   /*

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,8 +1,9 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
+import cors from "cors";
 import { storage } from "./storage";
 import { z } from "zod";
-import { insertResponseSchema, insertGateResponseSchema, insertCommissionSchema } from "@shared/schema";
+import { insertResponseSchema, insertGateResponseSchema } from "@shared/schema";
 import { setupAuth, isAuthenticated } from "./auth";
 import { commissionsLimiter } from "./middleware/security";
 
@@ -562,10 +563,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
   //
   // No auth wall (commissions are first-contact). Access is IP-rate-limited
   // (see commissionsLimiter in middleware/security.ts).
-  app.post("/api/commissions", commissionsLimiter, async (req, res) => {
+  const commissionsCors = cors({
+    origin: ["https://fobdongle.com", "https://www.fobdongle.com"],
+    methods: ["POST", "OPTIONS"],
+    credentials: false,
+    optionsSuccessStatus: 200,
+  });
+
+  app.options("/api/commissions", commissionsCors);
+  app.post("/api/commissions", commissionsCors, commissionsLimiter, async (req, res) => {
     try {
-      const parsed = insertCommissionSchema.parse(req.body);
-      if (parsed.ciphertext.length > 200_000 || parsed.algorithm.length > 64) {
+      const parsed = z.object({
+        algorithm: z.string().min(1),
+        ciphertext: z.string().min(1),
+      }).parse(req.body);
+      if (parsed.ciphertext.length > 100_000 || parsed.algorithm.length > 64) {
         return res.status(400).json({
           success: false,
           error: "Payload too large",
@@ -573,7 +585,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const row = await storage.createCommission(parsed);
-      console.log(`[commissions] stored (alg=${parsed.algorithm})`);
+      console.log(`[commissions] stored (id=${row.id})`);
       res.json({ success: true, message: "Commission received.", id: row.id });
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -6,6 +6,7 @@ import {
   newsletterEmails,
   paymentCodes,
   gateResponses,
+  commissions,
   type User,
   type InsertUser,
   type UpsertUser,
@@ -20,7 +21,9 @@ import {
   type PaymentCode,
   type InsertPaymentCode,
   type GateResponse,
-  type InsertGateResponse
+  type InsertGateResponse,
+  type Commission,
+  type InsertCommission
 } from "@shared/schema";
 import { db } from "./db";
 import { eq, and, gt, desc, sql } from "drizzle-orm";
@@ -67,6 +70,9 @@ export interface IStorage {
   getGateResponsesBySessionId(sessionId: string): Promise<GateResponse[]>;
   linkGateResponsesToUser(sessionId: string, userId: string): Promise<void>;
   getGateResponsesByUserId(userId: string): Promise<GateResponse[]>;
+
+  // Commission operations
+  createCommission(commission: InsertCommission): Promise<Commission>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -447,6 +453,15 @@ export class DatabaseStorage implements IStorage {
       .from(gateResponses)
       .where(eq(gateResponses.userId, userId))
       .orderBy(desc(gateResponses.createdAt));
+  }
+
+  // Commission operations
+  async createCommission(commission: InsertCommission): Promise<Commission> {
+    const [row] = await db
+      .insert(commissions)
+      .values(commission)
+      .returning();
+    return row;
   }
 }
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -72,7 +72,7 @@ export interface IStorage {
   getGateResponsesByUserId(userId: string): Promise<GateResponse[]>;
 
   // Commission operations
-  createCommission(commission: InsertCommission): Promise<Commission>;
+  createCommission(commission: InsertCommission): Promise<Pick<Commission, "id">>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -456,11 +456,11 @@ export class DatabaseStorage implements IStorage {
   }
 
   // Commission operations
-  async createCommission(commission: InsertCommission): Promise<Commission> {
+  async createCommission(commission: InsertCommission): Promise<Pick<Commission, "id">> {
     const [row] = await db
       .insert(commissions)
       .values(commission)
-      .returning();
+      .returning({ id: commissions.id });
     return row;
   }
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -107,6 +107,19 @@ export const responses = pgTable("responses", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
+// Commissions - opaque browser-encrypted first-contact messages.
+// Sender encrypts client-side (e.g. RSA-OAEP+AES-GCM in commission.html),
+// server stores the ciphertext verbatim, operator decrypts offline with
+// whatever private key matches the `algorithm` label.
+// No sender identity is captured server-side (no auth wall, no accounts).
+export const commissions = pgTable("commissions", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  algorithm: varchar("algorithm", { length: 64 }).notNull(),
+  ciphertext: text("ciphertext").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  deliveredAt: timestamp("delivered_at"),
+});
+
 // Gate responses - encrypted landing page questionnaire responses
 export const gateResponses = pgTable("gate_responses", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -199,6 +212,11 @@ export const insertPaymentCodeSchema = createInsertSchema(paymentCodes).pick({
   expiresAt: true,
 });
 
+export const insertCommissionSchema = createInsertSchema(commissions).pick({
+  algorithm: true,
+  ciphertext: true,
+});
+
 // Types
 export type User = typeof users.$inferSelect;
 export type GateResponse = typeof gateResponses.$inferSelect;
@@ -220,3 +238,6 @@ export type InsertNewsletterEmail = z.infer<typeof insertNewsletterEmailSchema>;
 
 export type PaymentCode = typeof paymentCodes.$inferSelect;
 export type InsertPaymentCode = z.infer<typeof insertPaymentCodeSchema>;
+
+export type Commission = typeof commissions.$inferSelect;
+export type InsertCommission = z.infer<typeof insertCommissionSchema>;

--- a/tests/unit/commissions-route.test.ts
+++ b/tests/unit/commissions-route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import cors from "cors";
+import express from "express";
+import rateLimit from "express-rate-limit";
+import request from "supertest";
+import { z } from "zod";
+
+describe("commissions endpoint behavior", () => {
+  let app: express.Express;
+  const createCommission = jest.fn();
+
+  const commissionsCors = cors({
+    origin: ["https://fobdongle.com", "https://www.fobdongle.com"],
+    methods: ["POST", "OPTIONS"],
+    credentials: false,
+    optionsSuccessStatus: 200,
+  });
+  const commissionsLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 5,
+    message: { error: "Too many commission submissions. Please try again later." },
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
+  beforeEach(() => {
+    app = express();
+    app.set("trust proxy", 1);
+    app.use(express.json());
+    app.options("/api/commissions", commissionsCors);
+    app.post("/api/commissions", commissionsCors, commissionsLimiter, async (req, res) => {
+      try {
+        const parsed = z.object({
+          algorithm: z.string().min(1),
+          ciphertext: z.string().min(1),
+        }).parse(req.body);
+        if (parsed.ciphertext.length > 100_000 || parsed.algorithm.length > 64) {
+          return res.status(400).json({
+            success: false,
+            error: "Payload too large",
+          });
+        }
+
+        const row = await createCommission(parsed);
+        res.json({ success: true, message: "Commission received.", id: row.id });
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          return res.status(400).json({
+            success: false,
+            error: "algorithm and ciphertext are required",
+          });
+        }
+        res.status(500).json({
+          success: false,
+          error: "Failed to process commission",
+        });
+      }
+    });
+
+    createCommission.mockReset();
+    createCommission.mockResolvedValue({ id: "commission-id-1" });
+  });
+
+  it("stores a valid commission", async () => {
+    const response = await request(app)
+      .post("/api/commissions")
+      .set("Origin", "https://fobdongle.com")
+      .set("X-Forwarded-For", "1.1.1.1")
+      .send({ algorithm: "rsa-oaep+aes-gcm", ciphertext: "abc123" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      message: "Commission received.",
+      id: "commission-id-1",
+    });
+    expect(response.headers["access-control-allow-origin"]).toBe("https://fobdongle.com");
+    expect(response.headers["access-control-allow-credentials"]).toBeUndefined();
+    expect(createCommission).toHaveBeenCalledWith({
+      algorithm: "rsa-oaep+aes-gcm",
+      ciphertext: "abc123",
+    });
+  });
+
+  it("rejects missing required fields", async () => {
+    const response = await request(app)
+      .post("/api/commissions")
+      .set("X-Forwarded-For", "2.2.2.2")
+      .send({ algorithm: "rsa-oaep+aes-gcm" });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      success: false,
+      error: "algorithm and ciphertext are required",
+    });
+    expect(createCommission).not.toHaveBeenCalled();
+  });
+
+  it("rejects payloads that exceed the route size cap", async () => {
+    const response = await request(app)
+      .post("/api/commissions")
+      .set("X-Forwarded-For", "3.3.3.3")
+      .send({
+        algorithm: "rsa-oaep+aes-gcm",
+        ciphertext: "a".repeat(100_001),
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      success: false,
+      error: "Payload too large",
+    });
+    expect(createCommission).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated submissions from the same IP", async () => {
+    const body = { algorithm: "rsa-oaep+aes-gcm", ciphertext: "abc123" };
+    const ip = "4.4.4.4";
+
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post("/api/commissions")
+        .set("X-Forwarded-For", ip)
+        .send(body)
+        .expect(200);
+    }
+
+    const limited = await request(app)
+      .post("/api/commissions")
+      .set("X-Forwarded-For", ip)
+      .send(body);
+
+    expect(limited.status).toBe(429);
+    expect(limited.body).toEqual({
+      error: "Too many commission submissions. Please try again later.",
+    });
+  });
+});


### PR DESCRIPTION
- shared/schema.ts: add commissions pgTable with id / algorithm /
  ciphertext / created_at / delivered_at, plus insertCommissionSchema
  and Commission types.
- server/storage.ts: add createCommission to IStorage and its Drizzle
  implementation.
- server/middleware/security.ts: add https://fobdongle.com to the CORS
  allowlist so commission.html can POST cross-origin; export a stricter
  commissionsLimiter (5 requests per hour per IP), with a Redis-backed
  variant that swaps in when REDIS_URL is set.
- server/routes.ts: mount POST /api/commissions behind that limiter.
  Validates with insertCommissionSchema plus defensive length caps
  (ciphertext <= 200_000, algorithm <= 64). Server never sees plaintext
  and never decrypts; the operator uses the algorithm label offline to
  pick the matching private key.
- migrations/0004_add_commissions.sql: creates the table + an index for
  the offline pipeline's undelivered query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated `POST /api/commissions` endpoint for encrypted first-contact submissions.
  * Submissions are validated for required `algorithm` and `ciphertext`, with a size cap, and return a success response including a tracking ID.
  * Added database persistence for commission submissions and delivery tracking.

* **Security**
  * Enforced per-source rate limiting for commission submissions (5 per hour).
  * Updated allowed CORS origins, including `http://localhost:5000`.

* **Tests**
  * Added unit tests covering validation, payload limits, error responses, persistence, and rate limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->