### PR TITLE
Optimize questionnaire performance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,18 +1,31 @@
 import { Switch, Route } from "wouter";
+import { lazy, Suspense } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAuth } from "@/hooks/useAuth";
-import AuthPage from "@/pages/auth";
-import AuthPortalPage from "@/pages/auth-portal";
-import AuthCallbackPage from "@/pages/auth-callback";
-import QuestionnairePage from "@/pages/questionnaire";
-import CompletionPage from "@/pages/completion";
-import ReviewDeclinedPage from "@/pages/review-declined";
-import SharedQuestionnairePage from "@/pages/shared-questionnaire";
-import AdminPage from "@/pages/admin";
-import NotFoundPage from "@/pages/not-found";
+
+const AuthPage = lazy(() => import("@/pages/auth"));
+const AuthPortalPage = lazy(() => import("@/pages/auth-portal"));
+const AuthCallbackPage = lazy(() => import("@/pages/auth-callback"));
+const QuestionnairePage = lazy(() => import("@/pages/questionnaire"));
+const CompletionPage = lazy(() => import("@/pages/completion"));
+const ReviewDeclinedPage = lazy(() => import("@/pages/review-declined"));
+const SharedQuestionnairePage = lazy(() => import("@/pages/shared-questionnaire"));
+const AdminPage = lazy(() => import("@/pages/admin"));
+const NotFoundPage = lazy(() => import("@/pages/not-found"));
+
+function PageLoading() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 dark:from-slate-900 dark:to-blue-950 flex items-center justify-center">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4" />
+        <p className="text-slate-600 dark:text-slate-400">Loading...</p>
+      </div>
+    </div>
+  );
+}
 
 function Router() {
   const { isAuthenticated, isLoading, error } = useAuth();
@@ -58,7 +71,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <Router />
+        <Suspense fallback={<PageLoading />}>
+          <Router />
+        </Suspense>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/client/src/pages/questionnaire.tsx
+++ b/client/src/pages/questionnaire.tsx
@@ -37,10 +37,10 @@ interface QuestionData {
     current: number;
     total: number;
   };
-  responses: Array<{
+  response: {
     questionId: number;
     answer: string;
-  }>;
+  } | null;
 }
 
 interface SessionData {
@@ -97,19 +97,16 @@ export default function QuestionnairePage() {
   // Update current answer when question data loads
   useEffect(() => {
     if (questionData?.question) {
-      const existingResponse = questionData.responses.find(
-        r => r.questionId === questionData.question.id
-      );
-      
-      if (existingResponse) {
-        setCurrentAnswer(existingResponse.answer);
-        setHasUnsavedChanges(false);
-      } else {
-        setCurrentAnswer("");
-        setHasUnsavedChanges(false);
-      }
+      setCurrentAnswer(questionData.response?.answer ?? "");
+      setHasUnsavedChanges(false);
     }
   }, [questionData]);
+
+  useEffect(() => {
+    if (session?.completed) {
+      setLocation(`/complete/${session.id}`);
+    }
+  }, [session?.completed, session?.id, setLocation]);
 
   // Handle answer changes
   const handleAnswerChange = (value: string) => {
@@ -223,7 +220,6 @@ export default function QuestionnairePage() {
 
   // Check if questionnaire is completed
   if (session?.completed) {
-    setLocation(`/complete/${session.id}`);
     return null;
   }
 

--- a/client/src/pages/shared-questionnaire.tsx
+++ b/client/src/pages/shared-questionnaire.tsx
@@ -45,7 +45,7 @@ export default function SharedQuestionnairePage() {
   const questionOrder = session.questionOrder as number[];
 
   // Sort responses according to the display order
-  const sortedResponses = responses.sort((a: any, b: any) => {
+  const sortedResponses = [...responses].sort((a: any, b: any) => {
     const aIndex = questionOrder.indexOf(a.questionId);
     const bIndex = questionOrder.indexOf(b.questionId);
     return aIndex - bIndex;

--- a/migrations/0005_add_questionnaire_lookup_indexes.sql
+++ b/migrations/0005_add_questionnaire_lookup_indexes.sql
@@ -1,0 +1,6 @@
+-- Keep the per-question interaction path index-backed as response history grows.
+CREATE INDEX IF NOT EXISTS idx_questionnaire_sessions_user_completed_at
+  ON questionnaire_sessions (user_id, completed, completed_at);
+
+CREATE INDEX IF NOT EXISTS idx_responses_session_question
+  ON responses (session_id, question_id);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,6 +36,21 @@ import { vpsStorageService } from "./services/vpsStorageService";
 import { encryptionService } from "./services/encryptionService";
 import { responseEncryptionService } from "./services/responseEncryptionService";
 
+function queueCompletionEmail(email: string, sessionId: string, questionOrder: number[]): void {
+  setImmediate(() => {
+    void (async () => {
+      try {
+        const encryptedResponses = await storage.getResponsesBySessionId(sessionId);
+        const responses = responseEncryptionService.decryptResponses(encryptedResponses);
+        const pdfBuffer = await pdfService.generateFormulationOfTruthPDF(responses, questionOrder);
+        await emailService.sendCompletionEmail(email, pdfBuffer);
+      } catch (error) {
+        console.error("Completion email delivery failed:", error);
+      }
+    })();
+  });
+}
+
 export async function registerRoutes(app: Express): Promise<Server> {
   // Auth middleware
   await setupAuth(app);
@@ -143,9 +158,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       const currentQuestion = questionService.getCurrentQuestion(session);
-      const encryptedResponses = await storage.getResponsesBySessionId(sessionId);
-      // Decrypt responses before returning to client
-      const responses = responseEncryptionService.decryptResponses(encryptedResponses);
+      const encryptedResponse = currentQuestion
+        ? await storage.getResponseBySessionAndQuestion(sessionId, currentQuestion.id)
+        : undefined;
+      const response = encryptedResponse
+        ? responseEncryptionService.decryptResponses([encryptedResponse])[0]
+        : undefined;
 
       res.json({
         question: currentQuestion,
@@ -153,10 +171,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
           current: session.currentQuestionIndex + 1,
           total: (session.questionOrder as number[]).length
         },
-        responses: responses.map(r => ({
-          questionId: r.questionId,
-          answer: r.answer
-        }))
+        response: response
+          ? {
+              questionId: response.questionId,
+              answer: response.answer,
+            }
+          : null,
       });
     } catch (error) {
       console.error('Get current question error:', error);
@@ -222,38 +242,26 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (nextQuestionIndex < questionOrder.length) {
         await storage.updateSessionProgress(sessionId, nextQuestionIndex);
       } else {
-        // Check if user has completed questionnaire in last 2 months
-        const existingCompletions = await storage.getUserCompletedSessions(userId);
+        // Only the newest completed session can be within the restriction window.
+        const recentCompletion = await storage.getMostRecentCompletedSession(userId);
         const twoMonthsAgo = new Date();
         twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
-        
-        const recentCompletion = existingCompletions.find(session => 
-          session.completedAt && new Date(session.completedAt) > twoMonthsAgo
-        );
 
-        if (recentCompletion) {
+        if (recentCompletion?.completedAt && recentCompletion.completedAt > twoMonthsAgo) {
           return res.status(400).json({ 
             message: 'You may only complete the questionnaire once every 2 months',
-            nextAvailable: new Date(new Date(recentCompletion.completedAt!).getTime() + (2 * 30 * 24 * 60 * 60 * 1000))
+            nextAvailable: new Date(recentCompletion.completedAt.getTime() + (2 * 30 * 24 * 60 * 60 * 1000))
           });
         }
 
-        // Complete session and generate PDF
+        // Complete the session, then queue document delivery.
         await storage.completeSession(sessionId, false);
 
-        // Get user and all responses for PDF (decrypt before PDF generation)
+        // Document generation and SMTP delivery are intentionally deferred so the
+        // final answer request is not held open by CPU and network work.
         const user = await storage.getUser(userId);
-        const encryptedAllResponses = await storage.getResponsesBySessionId(sessionId);
-        const allResponses = responseEncryptionService.decryptResponses(encryptedAllResponses);
-
         if (user?.email) {
-          // Generate and send PDF
-          const pdfBuffer = await pdfService.generateFormulationOfTruthPDF(
-            allResponses,
-            session.questionOrder as number[]
-          );
-
-          await emailService.sendCompletionEmail(user.email, pdfBuffer);
+          queueCompletionEmail(user.email, sessionId, session.questionOrder as number[]);
         }
       }
 
@@ -300,16 +308,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(401).json({ message: 'User not authenticated' });
       }
 
-      // Check if user has completed questionnaire recently (silent enforcement)
-      const existingCompletions = await storage.getUserCompletedSessions(userId);
+      // Only the newest completed session can be within the restriction window.
+      const recentCompletion = await storage.getMostRecentCompletedSession(userId);
       const restrictionPeriod = new Date();
       restrictionPeriod.setTime(restrictionPeriod.getTime() - (5688000 * 1000)); // 5,688,000 seconds ago
-      
-      const recentCompletion = existingCompletions.find(session => 
-        session.completedAt && new Date(session.completedAt) > restrictionPeriod
-      );
 
-      if (recentCompletion) {
+      if (recentCompletion?.completedAt && recentCompletion.completedAt > restrictionPeriod) {
         // Return a generic error without revealing timing information
         return res.status(400).json({ 
           message: 'Unable to complete the inquiry at this time'
@@ -338,14 +342,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Increment user completion count
       const updatedUser = await storage.incrementUserCompletionCount(userId);
 
-      // Decrypt responses for PDF generation
-      const responses = responseEncryptionService.decryptResponses(encryptedResponses);
-
-      // Generate and send PDF
-      const pdfBuffer = await pdfService.generateFormulationOfTruthPDF(responses, session.questionOrder as number[]);
-      
       if (updatedUser?.email) {
-        await emailService.sendCompletionEmail(updatedUser.email, pdfBuffer);
+        queueCompletionEmail(updatedUser.email, sessionId, session.questionOrder as number[]);
       }
 
       // Securely backup to VPS (non-blocking)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -49,6 +49,7 @@ export interface IStorage {
   updateSessionProgress(sessionId: string, questionIndex: number): Promise<void>;
   completeSession(sessionId: string, wantsReminder?: boolean, wantsToShare?: boolean): Promise<string | null>;
   getUserCompletedSessions(userId: string): Promise<QuestionnaireSession[]>;
+  getMostRecentCompletedSession(userId: string): Promise<QuestionnaireSession | undefined>;
 
   // Response operations
   getResponsesBySessionId(sessionId: string): Promise<Response[]>;
@@ -235,6 +236,19 @@ export class DatabaseStorage implements IStorage {
       .orderBy(desc(questionnaireSessions.completedAt));
   }
 
+  async getMostRecentCompletedSession(userId: string): Promise<QuestionnaireSession | undefined> {
+    const [session] = await db
+      .select()
+      .from(questionnaireSessions)
+      .where(and(
+        eq(questionnaireSessions.userId, userId),
+        eq(questionnaireSessions.completed, true)
+      ))
+      .orderBy(desc(questionnaireSessions.completedAt))
+      .limit(1);
+    return session || undefined;
+  }
+
   async getResponsesBySessionId(sessionId: string): Promise<Response[]> {
     return await db
       .select()
@@ -294,7 +308,8 @@ export class DatabaseStorage implements IStorage {
           eq(responses.sessionId, sessionId),
           eq(responses.questionId, questionId)
         )
-      );
+      )
+      .limit(1);
     return response || undefined;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -71,41 +71,55 @@ export const paymentCodes = pgTable("payment_codes", {
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });
 
-export const questionnaireSessions = pgTable("questionnaire_sessions", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  userId: varchar("user_id").notNull().references(() => users.id),
-  currentQuestionIndex: integer("current_question_index").default(0).notNull(),
-  questionOrder: jsonb("question_order").notNull(),
-  completed: boolean("completed").default(false).notNull(),
-  reviewingDeclined: boolean("reviewing_declined").default(false).notNull(),
-  completedAt: timestamp("completed_at"),
-  wantsReminder: boolean("wants_reminder").default(false).notNull(),
-  isShared: boolean("is_shared").default(false).notNull(),
-  shareId: varchar("share_id").unique(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const questionnaireSessions = pgTable(
+  "questionnaire_sessions",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    userId: varchar("user_id").notNull().references(() => users.id),
+    currentQuestionIndex: integer("current_question_index").default(0).notNull(),
+    questionOrder: jsonb("question_order").notNull(),
+    completed: boolean("completed").default(false).notNull(),
+    reviewingDeclined: boolean("reviewing_declined").default(false).notNull(),
+    completedAt: timestamp("completed_at"),
+    wantsReminder: boolean("wants_reminder").default(false).notNull(),
+    isShared: boolean("is_shared").default(false).notNull(),
+    shareId: varchar("share_id").unique(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("idx_questionnaire_sessions_user_completed_at").on(
+      table.userId,
+      table.completed,
+      table.completedAt,
+    ),
+  ],
+);
 
-export const responses = pgTable("responses", {
-  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
-  sessionId: varchar("session_id").notNull().references(() => questionnaireSessions.id),
-  questionId: integer("question_id").notNull(),
-  // Server-side AES-256-GCM encryption (default for all users)
-  // The 'answer' field stores the encrypted ciphertext (base64)
-  answer: text("answer").notNull(), // Encrypted ciphertext (base64)
-  iv: text("iv"), // Initialization vector for AES-256-GCM (base64)
-  tag: text("tag"), // Authentication tag for AES-256-GCM (base64)
-  salt: text("salt"), // Per-response salt for key derivation (base64)
-  encryptionType: varchar("encryption_type").default("server").notNull(), // 'server' | 'client' | 'plaintext' (legacy)
-  // For client-side encrypted responses (paid users with Model C encryption)
-  encryptedData: text("encrypted_data"), // X25519-encrypted response
-  nonce: text("nonce"), // Nonce for client-side encryption
-  // Version history for paid users
-  version: integer("version").default(1).notNull(),
-  previousVersionId: varchar("previous_version_id"), // Reference to previous version
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at").defaultNow().notNull(),
-});
+export const responses = pgTable(
+  "responses",
+  {
+    id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+    sessionId: varchar("session_id").notNull().references(() => questionnaireSessions.id),
+    questionId: integer("question_id").notNull(),
+    // Server-side AES-256-GCM encryption (default for all users)
+    // The 'answer' field stores the encrypted ciphertext (base64)
+    answer: text("answer").notNull(), // Encrypted ciphertext (base64)
+    iv: text("iv"), // Initialization vector (base64)
+    tag: text("tag"), // Authentication tag (base64)
+    salt: text("salt"), // Per-response salt for key derivation (base64)
+    encryptionType: varchar("encryption_type").default("server").notNull(), // 'server' | 'client' | 'plaintext' (legacy)
+    // For client-side encrypted responses (paid users with Model C encryption)
+    encryptedData: text("encrypted_data"), // X25519-encrypted response
+    nonce: text("nonce"), // Nonce for client-side encryption
+    // Version history for paid users
+    version: integer("version").default(1).notNull(),
+    previousVersionId: varchar("previous_version_id"), // Reference to previous version
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [index("idx_responses_session_question").on(table.sessionId, table.questionId)],
+);
 
 // Commissions - opaque browser-encrypted first-contact messages.
 // Sender encrypts client-side (e.g. RSA-OAEP+AES-GCM in commission.html),


### PR DESCRIPTION
The questionnaire was doing increasingly expensive work on every interaction: loading and decrypting all prior responses, scanning completion history, and holding completion requests open for PDF generation and SMTP delivery.

## Approach
- Return only the active response from the current-question API and add indexed single-response/session-completion lookups.
- Add migration `0005_add_questionnaire_lookup_indexes.sql` for the new PostgreSQL indexes.
- Queue PDF rendering and email delivery after the completion response is persisted, keeping the request-critical path short.
- Split React pages into lazy-loaded route chunks, move completion navigation out of render, and avoid mutating cached shared responses during sorting.

## Deployment note
Run migration `0005_add_questionnaire_lookup_indexes.sql` before deploying the application code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator while questionnaire pages load.
  * Completion emails and documents are now processed in the background, allowing completion requests to finish sooner.
* **Bug Fixes**
  * Improved questionnaire answer loading and session completion redirects.
  * Prevented shared questionnaire responses from being unintentionally reordered.
  * Improved handling of recent questionnaire completion limits.
* **Performance**
  * Improved response and session lookup speeds for smoother questionnaire interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->