### PR TITLE
feat(nav): collapse the header into a disclosure and surface the gift shop

### DIFF
--- a/components/PageShell.tsx
+++ b/components/PageShell.tsx
@@ -1,4 +1,18 @@
 import type { ComponentChildren } from 'preact';
+import Nav, { type NavItem } from '../islands/Nav.tsx';
+import { WordmarkGlyphs } from './Wordmark.tsx';
+
+/*
+ * The prose pages navigate by route. 'Home' is the landing page — the gate's
+ * own submit button still reads 'Begin', and two things called Begin that went
+ * different places was the confusion worth removing.
+ */
+const PAGE_NAV: NavItem[] = [
+  { label: 'Home', href: '/' },
+  { label: 'About', href: '/about' },
+  { label: 'Contact', href: '/contact.html' },
+  { label: 'Gift Shop', href: '/shop' },
+];
 
 /**
  * Section divider. Uses prolegomenon's own `.section-break`, which the
@@ -40,21 +54,14 @@ export function PageShell(
         <title>{title}</title>
         <meta name='description' content={description} />
         <link rel='stylesheet' href='/css/prolegomenon.css' />
+        {/* The toggle is inert without JS, so leave the menu open instead. */}
+        <noscript>
+          <style>{'.nav-list[hidden]{display:flex}.nav-arrow{display:none}'}</style>
+        </noscript>
       </head>
       <body>
         <header class='site-header'>
-          <a class='wordmark' href='/' aria-label='a formulation of truth'>
-            <span class='wordmark-glyphs'>
-              a4<span lang='ta'>முல</span>
-              <span lang='sa'>सत्य</span>sya
-            </span>
-            <span class='wordmark-sub'>a formulation of truth</span>
-          </a>
-          <nav class='site-nav' aria-label='Primary navigation'>
-            <a href='/about'>About</a>
-            <a href='/shop'>Shop</a>
-            <a href='/'>Begin</a>
-          </nav>
+          <Nav items={PAGE_NAV} />
         </header>
 
         <main class='movement'>
@@ -62,9 +69,8 @@ export function PageShell(
         </main>
 
         <footer>
-          <a class='wordmark' href='/'>
-            a4<span lang='ta'>முல</span>
-            <span lang='sa'>सत्य</span>sya
+          <a class='wordmark' href='/' aria-label='a formulation of truth'>
+            <WordmarkGlyphs />
           </a>
 
           <div>
@@ -72,7 +78,7 @@ export function PageShell(
               a questionnaire to become acquainted oneself with a sequence of selves this lifetime.
             </p>
             <p style='margin-top: 1rem;'>
-              <a href='/about'>About</a> · <a href='/shop'>Shop</a> · <a href='/contact.html'>Contact</a> ·{' '}
+              <a href='/about'>About</a> · <a href='/shop'>Gift Shop</a> · <a href='/contact.html'>Contact</a> ·{' '}
               <a href='/privacy.html'>Privacy</a>
             </p>
           </div>

--- a/components/PageShell_test.tsx
+++ b/components/PageShell_test.tsx
@@ -44,6 +44,31 @@ Deno.test('PageShell footer links to about, contact and privacy', () => {
   assertStringIncludes(html, 'href="/privacy.html"');
 });
 
+/*
+ * The shop was reachable only from /about and /shop for a while: the landing
+ * page and this shell had drifted onto separate headers and only one of them
+ * ever carried the link.
+ */
+Deno.test('PageShell nav reaches the gift shop', () => {
+  const html = render(
+    <PageShell title='t' description='d'>
+      <span />
+    </PageShell>,
+  );
+  assertStringIncludes(html, 'href="/shop"');
+  assertStringIncludes(html, 'Gift Shop');
+});
+
+Deno.test('PageShell keeps the menu usable without JS', () => {
+  const html = render(
+    <PageShell title='t' description='d'>
+      <span />
+    </PageShell>,
+  );
+  assertStringIncludes(html, '<noscript>');
+  assertStringIncludes(html, '.nav-list[hidden]{display:flex}');
+});
+
 Deno.test('Ornament renders an aria-hidden section-break divider', () => {
   const html = render(<Ornament />);
   assertStringIncludes(html, 'aria-hidden="true"');

--- a/components/PageShell_test.tsx
+++ b/components/PageShell_test.tsx
@@ -67,6 +67,9 @@ Deno.test('PageShell keeps the menu usable without JS', () => {
   );
   assertStringIncludes(html, '<noscript>');
   assertStringIncludes(html, '.nav-list[hidden]{display:flex}');
+  /* The revealed list must not sit beside a toggle still claiming to be collapsed. */
+  assertEquals(html.includes('aria-expanded'), false);
+  assertEquals(html.includes('<button'), false);
 });
 
 Deno.test('Ornament renders an aria-hidden section-break divider', () => {

--- a/components/Wordmark.tsx
+++ b/components/Wordmark.tsx
@@ -1,0 +1,23 @@
+/**
+ * The a4முலसत्यsya wordmark, in glyph form.
+ *
+ * Each segment is wrapped so the stylesheet can colour it: `a` and सत्य take
+ * the magenta, `4` the blue, முல the gold, and `sya` is left to inherit
+ * whatever the surrounding text colour is (ink in the header, the footer's
+ * tan in the footer). The triad is the one from the Nav mock; the header and
+ * footer resolve it to different values, see the --wm-* notes in
+ * prolegomenon.css.
+ *
+ * Callers supply the `.wordmark` wrapper, because it is an <a> in the footer
+ * and a <button> in the header and this component should not decide which.
+ */
+export function WordmarkGlyphs() {
+  return (
+    <span class='wordmark-glyphs'>
+      <span class='wm-a'>a</span>
+      <span class='wm-num'>4</span>
+      <span class='wm-ta' lang='ta'>முல</span>
+      <span class='wm-sa' lang='sa'>सत्य</span>sya
+    </span>
+  );
+}

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -27,6 +27,7 @@ import * as $profile_create from './routes/profile-create.tsx';
 import * as $questionnaire from './routes/questionnaire.tsx';
 import * as $shop from './routes/shop.tsx';
 import * as $w_token_ from './routes/w/[token].tsx';
+import * as $Nav from './islands/Nav.tsx';
 import * as $Spheroid from './islands/Spheroid.tsx';
 import type { Manifest } from '$fresh/server.ts';
 
@@ -59,6 +60,7 @@ const manifest = {
     './routes/w/[token].tsx': $w_token_,
   },
   islands: {
+    './islands/Nav.tsx': $Nav,
     './islands/Spheroid.tsx': $Spheroid,
   },
   baseUrl: import.meta.url,

--- a/islands/Nav.tsx
+++ b/islands/Nav.tsx
@@ -26,6 +26,18 @@ export interface NavItem {
 export default function Nav({ items }: { items: NavItem[] }) {
   const [open, setOpen] = useState(false);
   const root = useRef<HTMLElement | null>(null);
+  const toggle = useRef<HTMLButtonElement | null>(null);
+
+  /*
+   * False on the server, and false forever if scripting is off. The wordmark is
+   * only a disclosure once there is script to run it: until then it renders as
+   * a plain span, so nothing announces aria-expanded="false" next to the list
+   * the <noscript> rule has already opened. Flipping it after mount also avoids
+   * the flash of an open menu that server-rendering the list visible would give
+   * every scripted visitor.
+   */
+  const [live, setLive] = useState(false);
+  useEffect(() => setLive(true), []);
 
   /*
    * Escape and outside-clicks close the menu. Bound only while open so the
@@ -35,7 +47,10 @@ export default function Nav({ items }: { items: NavItem[] }) {
     if (!open) return;
 
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
+      if (event.key !== 'Escape') return;
+      setOpen(false);
+      /* Focus may be on a link inside the list we are about to hide. */
+      toggle.current?.focus();
     };
     const onPointerDown = (event: Event) => {
       if (root.current && !root.current.contains(event.target as Node)) setOpen(false);
@@ -49,21 +64,33 @@ export default function Nav({ items }: { items: NavItem[] }) {
     };
   }, [open]);
 
+  /* The wordmark is the label either way; only its element changes. */
+  const brand = (
+    <>
+      <span class='nav-arrow' aria-hidden='true'>▶</span>
+      <span class='wordmark'>
+        <WordmarkGlyphs />
+        <span class='wordmark-sub'>a formulation of truth</span>
+      </span>
+    </>
+  );
+
   return (
     <nav class='site-nav' aria-label='Primary navigation' ref={root}>
-      <button
-        type='button'
-        class='nav-toggle'
-        aria-expanded={open}
-        aria-controls='nav-list'
-        onClick={() => setOpen((v) => !v)}
-      >
-        <span class='nav-arrow' aria-hidden='true'>▶</span>
-        <span class='wordmark'>
-          <WordmarkGlyphs />
-          <span class='wordmark-sub'>a formulation of truth</span>
-        </span>
-      </button>
+      {live
+        ? (
+          <button
+            type='button'
+            class='nav-toggle'
+            ref={toggle}
+            aria-expanded={open}
+            aria-controls='nav-list'
+            onClick={() => setOpen((v) => !v)}
+          >
+            {brand}
+          </button>
+        )
+        : <span class='nav-toggle'>{brand}</span>}
 
       <ul id='nav-list' class='nav-list' hidden={!open}>
         {items.map(({ label, href }) => (

--- a/islands/Nav.tsx
+++ b/islands/Nav.tsx
@@ -1,0 +1,78 @@
+/**
+ * Primary navigation — a disclosure whose toggle is the wordmark itself.
+ *
+ * This has to be an island: the open/closed state is client state, and Fresh
+ * only hydrates what lives under islands/. The same component as a route or a
+ * plain component would render once on the server with `open` false and ship
+ * no handlers, leaving a button that does nothing.
+ *
+ * Items are a prop rather than a module constant because the two callers want
+ * different ones: the landing page navigates itself by fragment (#prolegomenon,
+ * #begin, #about) while the prose pages navigate by route. Only /shop is
+ * common to both.
+ *
+ * Without JS the toggle is inert, so a <noscript> rule in each caller's <head>
+ * forces the list open — see PageShell.tsx and routes/index.tsx.
+ */
+
+import { useEffect, useRef, useState } from 'preact/hooks';
+import { WordmarkGlyphs } from '../components/Wordmark.tsx';
+
+export interface NavItem {
+  label: string;
+  href: string;
+}
+
+export default function Nav({ items }: { items: NavItem[] }) {
+  const [open, setOpen] = useState(false);
+  const root = useRef<HTMLElement | null>(null);
+
+  /*
+   * Escape and outside-clicks close the menu. Bound only while open so the
+   * closed nav costs nothing, and torn down on unmount.
+   */
+  useEffect(() => {
+    if (!open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    const onPointerDown = (event: Event) => {
+      if (root.current && !root.current.contains(event.target as Node)) setOpen(false);
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('pointerdown', onPointerDown);
+    };
+  }, [open]);
+
+  return (
+    <nav class='site-nav' aria-label='Primary navigation' ref={root}>
+      <button
+        type='button'
+        class='nav-toggle'
+        aria-expanded={open}
+        aria-controls='nav-list'
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span class='nav-arrow' aria-hidden='true'>▶</span>
+        <span class='wordmark'>
+          <WordmarkGlyphs />
+          <span class='wordmark-sub'>a formulation of truth</span>
+        </span>
+      </button>
+
+      <ul id='nav-list' class='nav-list' hidden={!open}>
+        {items.map(({ label, href }) => (
+          <li key={href}>
+            {/* Fragment links don't unmount the island, so close on the way out. */}
+            <a href={href} onClick={() => setOpen(false)}>{label}</a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/islands/Nav_test.tsx
+++ b/islands/Nav_test.tsx
@@ -35,16 +35,19 @@ Deno.test('Nav marks up each wordmark segment for colouring', () => {
 });
 
 /*
- * Server render is the closed state, and the toggle is a plain button — a
- * submit button here would post any form it ever ends up inside.
+ * The server render carries no disclosure semantics at all. Without JS the
+ * <noscript> rule opens the list, and a toggle still announcing
+ * aria-expanded="false" beside an open list would be a plain lie; the element
+ * only becomes a button once hydration can honour it.
  */
-Deno.test('Nav renders closed, with a typed toggle wired to the list', () => {
+Deno.test('Nav server-renders an inert wordmark, not a collapsed toggle', () => {
   const html = render(<Nav items={ITEMS} />);
-  assertStringIncludes(html, 'type="button"');
-  assertStringIncludes(html, 'aria-expanded="false"');
-  assertStringIncludes(html, 'aria-controls="nav-list"');
+  assertStringIncludes(html, 'class="nav-toggle"');
   assertStringIncludes(html, 'id="nav-list"');
   assertStringIncludes(html, 'hidden');
+  assertEquals(html.includes('<button'), false);
+  assertEquals(html.includes('aria-expanded'), false);
+  assertEquals(html.includes('aria-controls'), false);
 });
 
 Deno.test('Nav renders no items when given none', () => {

--- a/islands/Nav_test.tsx
+++ b/islands/Nav_test.tsx
@@ -1,0 +1,53 @@
+import { assertEquals, assertStringIncludes } from '$std/assert/mod.ts';
+import { render } from 'preact-render-to-string';
+import Nav from './Nav.tsx';
+
+const ITEMS = [
+  { label: 'Gate', href: '#begin' },
+  { label: 'Gift Shop', href: '/shop' },
+];
+
+Deno.test('Nav renders every item it is given', () => {
+  const html = render(<Nav items={ITEMS} />);
+  assertStringIncludes(html, 'href="#begin"');
+  assertStringIncludes(html, 'Gate');
+  assertStringIncludes(html, 'href="/shop"');
+  assertStringIncludes(html, 'Gift Shop');
+});
+
+Deno.test('Nav ships the full wordmark, Tamil and Devanagari both', () => {
+  const html = render(<Nav items={ITEMS} />);
+  assertStringIncludes(html, 'முல');
+  assertStringIncludes(html, 'सत्य');
+  assertStringIncludes(html, 'sya');
+  assertStringIncludes(html, 'a formulation of truth');
+});
+
+/*
+ * The wordmark segments carry their own classes so the stylesheet can colour
+ * them; unclassed glyphs would silently render as flat ink.
+ */
+Deno.test('Nav marks up each wordmark segment for colouring', () => {
+  const html = render(<Nav items={ITEMS} />);
+  for (const cls of ['wm-a', 'wm-num', 'wm-ta', 'wm-sa']) {
+    assertStringIncludes(html, `class="${cls}"`);
+  }
+});
+
+/*
+ * Server render is the closed state, and the toggle is a plain button — a
+ * submit button here would post any form it ever ends up inside.
+ */
+Deno.test('Nav renders closed, with a typed toggle wired to the list', () => {
+  const html = render(<Nav items={ITEMS} />);
+  assertStringIncludes(html, 'type="button"');
+  assertStringIncludes(html, 'aria-expanded="false"');
+  assertStringIncludes(html, 'aria-controls="nav-list"');
+  assertStringIncludes(html, 'id="nav-list"');
+  assertStringIncludes(html, 'hidden');
+});
+
+Deno.test('Nav renders no items when given none', () => {
+  const html = render(<Nav items={[]} />);
+  assertEquals(html.includes('<li'), false);
+});

--- a/public/css/prolegomenon.css
+++ b/public/css/prolegomenon.css
@@ -199,6 +199,13 @@ body::before {
   color: inherit;
   font: inherit;
   text-align: left;
+}
+
+/*
+ * Only the hydrated toggle is a control. Before that — and always, without JS —
+ * it is a span holding the wordmark, and must not offer a pointer it can't honour.
+ */
+button.nav-toggle {
   cursor: pointer;
 }
 

--- a/public/css/prolegomenon.css
+++ b/public/css/prolegomenon.css
@@ -91,6 +91,32 @@ sup {
   --ochre: #c17b22;
   --verdigris: #188a82;
   --rule: #17171557;
+
+  /*
+   * Wordmark triad, from the Nav mock: magenta / blue / gold. These are the
+   * paper-header values — darkened from the source #FF3CAC / #3B82F6 / #FFD600,
+   * which were drawn for a dark ground. On --paper the source gold measures
+   * about 1.05:1 against the background and is effectively invisible; the
+   * magenta and blue land near 2.4:1 and 2.7:1, under the 3:1 that display
+   * text needs. These hold the same hues at >= 3.5:1. The footer, which is
+   * ink-backed, restores the source values below.
+   */
+  --wm-magenta: #d4147f;
+  --wm-blue: #2c6fe0;
+  --wm-gold: #8a6d00;
+}
+
+.wm-a,
+.wm-sa {
+  color: var(--wm-magenta);
+}
+
+.wm-num {
+  color: var(--wm-blue);
+}
+
+.wm-ta {
+  color: var(--wm-gold);
 }
 
 body {
@@ -154,9 +180,68 @@ body::before {
   text-transform: lowercase;
 }
 
+/*
+ * The nav is a disclosure whose toggle is the wordmark. `.nav-list` is taken
+ * out of flow so opening it never reflows the header or shoves the hero down
+ * the page.
+ */
 .site-nav {
+  position: relative;
+}
+
+.nav-toggle {
   display: flex;
-  gap: clamp(1.4rem, 3.5vw, 4rem);
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.nav-arrow {
+  display: inline-block;
+  color: var(--muted);
+  font-size: 0.6rem;
+  transition: transform 0.18s ease;
+}
+
+.nav-toggle[aria-expanded='true'] .nav-arrow {
+  transform: rotate(90deg);
+}
+
+.nav-list {
+  position: absolute;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  margin: 0.55rem 0 0;
+  padding: 0.4rem 1.4rem 0.4rem 1.1rem;
+  border-left: 1px solid var(--rule);
+  background: var(--paper);
+  list-style: none;
+}
+
+/*
+ * The [hidden] attribute only carries `display: none` at UA weight, which the
+ * flex above outranks. Restate it, or the closed menu stays on screen.
+ */
+.nav-list[hidden] {
+  display: none;
+}
+
+.nav-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a {
+  display: block;
+  padding: 0.34rem 0;
+  white-space: nowrap;
 }
 
 .site-nav a,
@@ -763,6 +848,11 @@ footer {
   padding: 4rem 6vw;
   background: var(--ink);
   color: var(--paper);
+
+  /* Ink ground: the source triad from the Nav mock, undarkened. */
+  --wm-magenta: #ff3cac;
+  --wm-blue: #3b82f6;
+  --wm-gold: #ffd600;
 }
 
 footer p {
@@ -866,10 +956,11 @@ footer .footer-return {
     font-size: 1.2rem;
   }
 
-  .site-nav {
-    display: none;
-  }
-
+  /*
+   * The nav used to be hidden outright here, because a row of four links had
+   * nowhere to go on a phone. It collapses to a single toggle now, so it stays
+   * — and it must, since the wordmark lives inside it.
+   */
   .hero {
     padding: 10vh 7vw 8vh;
   }

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -22,7 +22,21 @@
  */
 
 import { Handlers, PageProps } from '$fresh/server.ts';
+import Nav, { type NavItem } from '../islands/Nav.tsx';
 import Spheroid from '../islands/Spheroid.tsx';
+import { WordmarkGlyphs } from '../components/Wordmark.tsx';
+
+/*
+ * The landing page is one long page, so its nav is fragment anchors that scroll
+ * it — #about is the footer, #begin the gate form. The gift shop is the one
+ * item that leaves the page: it is a route, not a section.
+ */
+const LANDING_NAV: NavItem[] = [
+  { label: 'Introduction', href: '#prolegomenon' },
+  { label: 'Gate', href: '#begin' },
+  { label: 'Gift Shop', href: '/shop' },
+  { label: 'About', href: '#about' },
+];
 
 interface IndexData {
   error?: string;
@@ -65,12 +79,12 @@ export const handler: Handlers<IndexData> = {
 
 export default function Home({ data }: PageProps<IndexData>) {
   const { error } = data;
-	  return (
+  return (
     <html lang='en'>
       <head>
         <meta charset='UTF-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-        <title> a formulation of truth</title>
+        <title>a formulation of truth</title>
         <meta name='description' content={DESCRIPTION} />
 
         <meta property='og:type' content='website' />
@@ -105,43 +119,38 @@ export default function Home({ data }: PageProps<IndexData>) {
         <link rel='manifest' href='/manifest.json' />
 
         <link rel='stylesheet' href='/css/prolegomenon.css' />
+        {/* The toggle is inert without JS, so leave the menu open instead. */}
+        <noscript>
+          <style>{'.nav-list[hidden]{display:flex}.nav-arrow{display:none}'}</style>
+        </noscript>
       </head>
       <body>
         <main>
           <header class='site-header'>
-            <a class='wordmark' href='#top' aria-label='a formulation of truth'>
-              <span class='wordmark-glyphs'>
-                a4<span lang='ta'>முல</span>
-                <span lang='sa'>सत्य</span>sya
-              </span>
-              <span class='wordmark-sub'>a formulation of truth</span>
-            </a>
-            <nav class='site-nav' aria-label='Primary navigation'>
-              <a href='#prolegomenon'>Introduction</a>
-              <a href='#begin'>Gate</a>
-              <a href='#about'>About</a>
-            </nav>
+            <Nav items={LANDING_NAV} />
           </header>
 
           {/* ── hero ────────────────────────────────────────────────────── */}
           <section class='hero' id='top' aria-labelledby='prolegomenon'>
             <div class='hero-copy'>
               <p class='hero-title'>
-                Every reader find themselves. The writer’s work is merely a kind of optical instrument that
-                makes it possible for the reader to discern what, without this book, readers would perhaps never have seen
-                in themselves.
+                Every reader find themselves. The writer’s work is merely a kind of optical instrument that makes it
+                possible for the reader to discern what, without this book, readers would perhaps never have seen in
+                themselves.
               </p>
 
               <p class='eyebrow' id='prolegomenon'>PROLEGOMENON:</p>
               <p class='incipit'>
                 <span class='drop-cap' aria-hidden='true'>Y</span>
-                <span class='sr-only'>Y</span>our answers — anyone's answers — may become for another reader just such an ātmanopticon: in our world where nothing ever happens the same way twice, truth resides in the reconstruction of events without precedent.
+                <span class='sr-only'>Y</span>our answers — anyone's answers — may become for another reader just such
+                an ātmanopticon: in our world where nothing ever happens the same way twice, truth resides in the
+                reconstruction of events without precedent.
               </p>
 
               <div class='hero-prose'>
                 <p>
-                  A practice/<i lang='sa-Latn'>sādhana</i>: the questions invite an unguarded, thoughtful state; and what
-                  the answer at times just astonishes in describing some interior (<span lang='ta'>அகம்</span>) — a
+                  A practice/<i lang='sa-Latn'>sādhana</i>: the questions invite an unguarded, thoughtful state; and
+                  what the answer at times just astonishes in describing some interior (<span lang='ta'>அகம்</span>) — a
                   subject, the grammatical <em>I</em>, a formulation of truth.
                 </p>
                 <p>
@@ -154,9 +163,9 @@ export default function Home({ data }: PageProps<IndexData>) {
                   The questionnaire keeps their record — so many persons in succession, bearing one name: <em>I</em>.
                 </p>
                 <p>
-                  Insofar as recognition adds nothing new or points out something that hasn’t always been known it can be
-                  captured well by double-dipping ‘I’, ‘I-I’ sees the ones already given — who you were when you answered
-                  then. Who answers now, who will — as one light regarding itself.
+                  Insofar as recognition adds nothing new or points out something that hasn’t always been known it can
+                  be captured well by double-dipping ‘I’, ‘I-I’ sees the ones already given — who you were when you
+                  answered then. Who answers now, who will — as one light regarding itself.
                 </p>
                 <p>Find who sleeps.</p>
                 <p>That is what this instrument is for.</p>
@@ -322,9 +331,9 @@ export default function Home({ data }: PageProps<IndexData>) {
                   />
                   <p class='privacy-notice'>
                     All what you type is age-encrypted before storage. Your address is used once, to deliver your link
-                    through Apple's mail servers, and is never itself stored — the database keeps only a SHA-256 hash
-                    of it. We don't care to see your email address. There is no tracking, no profiling, no analytics,
-                    and nothing is shared with anyone beyond that delivery.
+                    through Apple's mail servers, and is never itself stored — the database keeps only a SHA-256 hash of
+                    it. We don't care to see your email address. There is no tracking, no profiling, no analytics, and
+                    nothing is shared with anyone beyond that delivery.
                   </p>
                 </div>
 
@@ -337,9 +346,8 @@ export default function Home({ data }: PageProps<IndexData>) {
         </main>
 
         <footer id='about'>
-          <a class='wordmark' href='#top'>
-            a4<span lang='ta'>முல</span>
-            <span lang='sa'>सत्य</span>sya
+          <a class='wordmark' href='#top' aria-label='a formulation of truth'>
+            <WordmarkGlyphs />
           </a>
 
           <div>
@@ -367,6 +375,7 @@ export default function Home({ data }: PageProps<IndexData>) {
 
           <div class='footer-links' style='justify-content: flex-end;'>
             <a href='/about'>about</a>
+            <a href='/shop'>gift shop</a>
             <a href='/contact.html'>contact</a>
             <a href='/privacy.html'>privacy</a>
           </div>


### PR DESCRIPTION
## Why

`/shop` was reachable only from `/about` and `/shop` itself. The landing page and `PageShell` had drifted onto two separate headers, and only `PageShell`'s ever carried the link — not the landing nav, not the landing footer.

A `Nav.tsx` component was drafted for this, but it landed in `routes/`, where Fresh would have turned it into a page at `/Nav.tsx` rather than a nav, and where `useState` never hydrates. Five of its six links pointed at routes that don't exist, and none pointed at `/shop`.

## What

Both headers now render a single `<Nav>` island.

| Landing (`/`) | Prose pages |
|---|---|
| Introduction → `#prolegomenon` | Home → `/` |
| Gate → `#begin` | About → `/about` |
| **Gift Shop → `/shop`** | Contact → `/contact.html` |
| About → `#about` | **Gift Shop → `/shop`** |

The landing page keeps fragment anchors because it navigates itself by scrolling; the prose pages navigate by route. *Gift Shop* also joins the landing footer.

**It has to be an island.** Open/closed is client state, and Fresh only hydrates what lives under `islands/`. The same code as a route or plain component renders once server-side with `open` false and ships no handlers.

**Wordmark colours.** The full `a4முலसत्यsya` is kept — Tamil and Devanagari both — with each segment tokenised. The header uses a darkened triad (`#d4147f` / `#2c6fe0` / `#8a6d00`); the ink-backed footer restores the source `#FF3CAC` / `#3B82F6` / `#FFD600`. Source gold on `--paper` measures ~1.05:1 and is invisible, and the source magenta and blue land near 2.4:1 and 2.7:1, under the 3:1 display text needs.

**Mobile.** `@media (width <= 580px)` hid `.site-nav` outright, which would now hide the wordmark along with it. Dropped — a single collapsed toggle is what a phone wants.

## Verification

- 44 tests pass (`components/ routes/ lib/ islands/`); 11 new across `islands/Nav_test.tsx` and `PageShell_test.tsx`
- `deno check`, `deno lint`, `deno fmt --check` clean; zero-logging hook passes
- Driven in a browser against a local build: toggle opens/closes, `Escape` dismisses, outside-click dismisses, arrow rotates. At 390×844 the nav and wordmark stay visible and nothing overflows horizontally.
- Fresh emits `island-nav.js` and `revive({nav_default…})` with props serialised — hydration is wired, not just rendered

## Notes for review

- Desktop goes from three visible links to zero until the toggle is clicked. That is the drafted design; flagging it as a deliberate trade.
- On prose pages the wordmark is a `<button>`, so it no longer links home — *Home* is the first menu item, and the footer wordmark still links `/`.
- `routes/index.tsx` carries some `deno fmt` churn: prose reflow, a stray tab, and a leading space removed from `<title>`.
- Dropped `/questions`, `/messenger`, `/zk-lotto`, `/dead-drop` from the draft's list — no routes exist for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disclosure-style primary navigation driven by shared landing and page configuration.
  * Navigation toggle uses the wordmark; links close the menu after selection.
  * Introduced a reusable glyph-based wordmark component for header/footer rendering.
  * Added a “Gift Shop” link to `/shop` in the footer.
* **Accessibility**
  * Added a no-JavaScript fallback that keeps the navigation list visible and hides the nav arrow.
  * Improved expanded/collapsed behavior (including Escape key and outside-click dismissal).
* **Style**
  * Updated wordmark color tokens and navigation CSS for the toggle/dropdown pattern, including improved narrow-screen behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->