### PR TITLE
Punctuate the gate's opening series with commas

### DIFF
--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -281,7 +281,7 @@ export default function Home({ data }: PageProps<IndexData>) {
               <p class='gate-eyebrow'>a gate:</p>
               <h2 class='gate-title'>we meet @ this gate:</h2>
               <p class='gate-description'>
-                Often a thought or memory or fantasy floats into awareness only to be censored by merely the
+                Often a thought, memory, or fantasy floats into awareness only to be censored by merely the
                 anticipation of scolding, punishment, shame, or rejection. Inhibition causes us to shy away from that
                 prohibitive act. Human beings are ruled by inhibition. On measure we like this — I wanted to kill my
                 boyfriend the other night! But I didn’t. Not because homicide is impossible but because inhibition is


### PR DESCRIPTION
The gate description opened with "a thought or memory or fantasy" — polysyndeton — while the very next clause in the same sentence used a comma series with the Oxford comma: "scolding, punishment, shame, or rejection". One sentence, two patterns.

Use commas for both. Keeping the bare nouns ("a thought, memory, or fantasy") rather than repeating the article makes the two series identical in shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Expanded the gate description to clarify that fantasy-related thoughts are also subject to censorship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->