### PR TITLE
ci: type-check main.ts so boot-breaking imports fail the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,15 @@ jobs:
 
       - name: Type check
         run: |
+          # main.ts is the production entrypoint: if it does not type check, the
+          # service cannot boot. It was missing from this list when e27764a merged
+          # `import { initPool } from './lib/db.ts'` — a symbol lib/db.ts has never
+          # exported. Nothing caught it, and nothing could: the deployed process had
+          # started before that commit was checked out, so it kept serving old code
+          # and the break stayed invisible for two days, until a routine restart
+          # crash-looped the site into 502. Keep main.ts first in this list.
           deno check \
+            main.ts \
             data/shop.ts \
             components/PageShell.tsx \
             routes/about.tsx \


### PR DESCRIPTION
## What

Adds `main.ts` to the `deno check` list in the CI Type check step. One path.

## Why

`main.ts` is the production entrypoint. A module-resolution error there does not degrade the site — it stops the service from booting at all. It was the one file whose failure is unrecoverable, and the only one not being checked.

This gap already caused an outage:

1. `e27764a` merged `import { initPool } from './lib/db.ts'` — a symbol `lib/db.ts` has never exported.
2. CI passed, because `main.ts` was not in the check list.
3. Production kept looking healthy for **two days**. The running process had started before that commit was checked out, so it served the previous code from memory and never re-read `main.ts`.
4. A restart for an unrelated reason crash-looped the service into 502 until `d59e8ef` was deployed.

The failure was invisible precisely because nothing restarted. CI is the only layer that catches it before it becomes an outage.

## Verification

Both directions checked, not assumed:

- At `e27764a` (the broken commit), the new check **fails** as intended:
  ```
  TS2305 [ERROR]: Module '.../lib/db.ts' has no exported member 'initPool'.
  import { initPool } from './lib/db.ts';   at main.ts:60
  ```
- On current `production`, the full step **passes** (`exit=0`), so this does not land a red CI.

## Risk

Minimal. No `${{ }}` interpolation is introduced — the change is a static file path inside an existing `run:` block, so it adds no workflow-injection surface. If `main.ts` ever legitimately cannot type check, the correct response is to fix `main.ts`, not to drop it from this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CI type-checking to include the production entrypoint.
  * Added documentation clarifying the type-check configuration and import validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->