### PR TITLE
Count discrete visits from the co-op QR code

### DIFF
--- a/db/migrations/009_qr_scan_counts.sql
+++ b/db/migrations/009_qr_scan_counts.sql
@@ -1,0 +1,34 @@
+-- QR scan counting for public QR-bearing objects.
+-- Spec: docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+--
+-- Neither table stores an address or a user agent. A visitor is identified
+-- only by HMAC(salt_for_today, ip || LF || user_agent), and the salt is
+-- deleted after 48 hours -- after which the rows below cannot be recomputed
+-- by anyone, so a past day's visitors are permanently un-relinkable.
+
+CREATE TABLE IF NOT EXISTS fresh_qr_salts (
+  day  DATE  PRIMARY KEY,
+  salt BYTEA NOT NULL                        -- 32 random bytes, minted on the
+                                             -- day's first visit, dropped at 48h
+);
+
+CREATE TABLE IF NOT EXISTS fresh_qr_scans (
+  slug         TEXT        NOT NULL,         -- a column, not a table name, so
+                                             -- future QR objects share this
+  day          DATE        NOT NULL,         -- the dedup window
+  visitor_hash TEXT        NOT NULL,         -- 64 hex chars; opaque once the
+                                             -- day's salt is pruned
+  bot          BOOLEAN     NOT NULL DEFAULT FALSE,  -- link unfurler, counted
+                                                    -- but excluded by default
+  first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  hits         INT         NOT NULL DEFAULT 1,      -- re-scans within the day
+
+  -- Distinct visitors is then the row count and raw scans is SUM(hits), so
+  -- neither number can be lost to a bug in the other.
+  PRIMARY KEY (slug, day, visitor_hash)
+);
+
+-- The report reads by slug over a date range; the primary key leads with slug
+-- so that is already covered. This index serves the per-day rollup.
+CREATE INDEX IF NOT EXISTS fresh_qr_scans_slug_day_idx
+  ON fresh_qr_scans (slug, day);

--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -131,6 +131,14 @@ is recomputable forever by anyone holding `SECRET`, so every past day stays
 re-linkable and the daily rotation is decorative. Random-and-deleted means that
 once a salt is gone, its rows are opaque bytes even to us.
 
+**Known limit on the 48h guarantee.** Pruning happens in the request path,
+because this app has no scheduler and adding one is a larger decision than the
+feature warrants. If scanning stops, pruning stops with it, and salts outlive
+the window for as long as the route is idle — so the guarantee is "48 hours,
+provided the object is being scanned", not unconditionally. If the co-op node
+turns out to see long quiet stretches, move the `DELETE` to a scheduled UTC
+task; it is written to be safe to run from anywhere.
+
 ### Bots
 
 Link unfurlers (Signal, iMessage, WhatsApp, Slack) fetch a URL to build a

--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -1,0 +1,189 @@
+# Co-op QR scan counting
+
+**Date:** 2026-08-11
+**Status:** approved, not implemented
+**Scope:** this repo only. The firmware half is
+`heltec-dd-node/docs/superpowers/specs/2026-08-11-coop-oled-content-rotation-design.md`.
+
+## Problem
+
+A Heltec V4 OLED node is being placed in public at the Willy St Co-op. Its
+screen shows a QR code, and the operator wants a server-side report of how
+many discrete visits that code produces.
+
+Three things stand in the way, all verified 2026-08-11:
+
+1. **The QR points at a URL that does not exist.** Firmware
+   `DD_QR_DEFAULT_TEXT` is `aformulationoftruth.com/Level5`, and there is no
+   `/Level5` route in this app. Every scan today is a 404.
+2. **`lib/metrics.ts` cannot answer the question.** It is explicitly
+   in-memory, single-process, one-minute buckets. It resets on every deploy,
+   so it cannot report a total since the object was placed.
+3. **`fresh_encounters` counts conversions, not scans.** A row appears only
+   when a scanner submits their email at the gate (`routes/api/gate-submit.ts:164`).
+   Someone who scans, reads, and leaves is invisible to it.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| URL | `aformulationoftruth.com/WillyStCo-op` | Human-readable; re-pointable later without reflashing the node |
+| "Discrete" | Hashed IP + user-agent, deduped per UTC day | Works when cookies are blocked; owner accepted the privacy trade-off over a cookie-based count |
+| Salt lifetime | Random per day, deleted at 48h | Makes past days permanently un-recomputable, which is what "non-linkable across days" has to mean to be true |
+| Report surface | CLI script | Adds no public HTTP surface to guard |
+| Landing | `302` to `/w/<token>` | Reuses the existing invitation page and its encounter machinery |
+
+## Architecture
+
+```
+QR scan
+  -> GET /WillyStCo-op          record the visit, never render the slug
+  -> 302
+  -> GET /w/<coop-token>        existing page: greets, plants 24h cookie
+  -> gate                       existing: fresh_encounters on email submit
+```
+
+Counting lives on the slug route, not on `/w/[token]`. That keeps the vanity
+URL and the counter together, leaves the wearable page untouched, and lets the
+QR be re-pointed at a different destination later without moving the counter.
+
+The result is two independent numbers, which answer different questions:
+**scans** (this spec) and **conversions** (`fresh_encounters`, already built).
+
+### Configuration
+
+`COOP_WEARABLE_TOKEN` — the seeded token the slug redirects to. Absent or
+malformed, the route redirects to `/` and increments
+`errors.config.qr_token_missing`, rather than 404ing a printed code.
+
+### The co-op wearable token
+
+`/w/[token]` requires a row in `fresh_wearables`. The co-op drop gets its own,
+seeded with `tools/seed-wearable.ts`, owned by the site rather than a person.
+
+This is a hard requirement, not a convenience. `tools/seed-wearable.ts:29`
+records that a wearable token is a bearer credential: anyone holding one can
+pose as a scan of that object and graft themselves onto the owner's graph.
+Printing one on a QR in a grocery store makes it public by definition. A
+dedicated site-owned token means that exposure is intended and bounded; a
+personal token would leak a real person's graph edge to every passerby.
+
+### Counting
+
+```
+visitor_hash = HMAC-SHA256(salt_for_today, ip + "\n" + user_agent)
+```
+
+The IP exists only as a local variable feeding the HMAC. It is never stored,
+never logged, and never returned.
+
+`getClientIp()` lives in `lib/client-ip.ts`, honoring `TRUST_PROXY`.
+
+**Found during implementation:** `routes/api/contact.ts` has a private copy of
+this function, but that file exists on `production` and **not** on `main`,
+which is where this work is branched from — so the two cannot be reconciled in
+this change. When it reaches production, delete contact.ts's copy and import
+the shared one. Nothing will fail to compile to remind you, which is precisely
+why it is written down here and in the module's header.
+
+### Schema
+
+`db/migrations/009_qr_scan_counts.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS fresh_qr_salts (
+  day  DATE PRIMARY KEY,
+  salt BYTEA NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fresh_qr_scans (
+  slug         TEXT        NOT NULL,
+  day          DATE        NOT NULL,
+  visitor_hash TEXT        NOT NULL,   -- 64 hex chars
+  bot          BOOLEAN     NOT NULL DEFAULT FALSE,
+  first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  hits         INT         NOT NULL DEFAULT 1,
+  PRIMARY KEY (slug, day, visitor_hash)
+);
+```
+
+`visitor_hash` is TEXT rather than the BYTEA this spec first specified:
+`lib/crypto.ts::hmacSign` already returns hex, and round-tripping it through
+bytea would add an encoding step with nothing to show for it.
+
+Insert with `ON CONFLICT (slug, day, visitor_hash) DO UPDATE SET hits = hits + 1`.
+One table yields both numbers: distinct visitors is the row count, raw scans is
+`SUM(hits)`. Neither can be lost to a bug in the other.
+
+`slug` is a column rather than a table name so future QR-bearing objects share
+this machinery.
+
+### Salt lifecycle
+
+On the first visit of a UTC day, generate 32 random bytes and
+`INSERT ... ON CONFLICT (day) DO NOTHING`, then `SELECT` the winner — the
+conflict path is what makes two simultaneous first-visits agree on one salt
+instead of racing. The same code path prunes:
+`DELETE FROM fresh_qr_salts WHERE day < CURRENT_DATE - 1`.
+
+Deriving the salt from a long-lived secret was rejected. `HMAC(SECRET, date)`
+is recomputable forever by anyone holding `SECRET`, so every past day stays
+re-linkable and the daily rotation is decorative. Random-and-deleted means that
+once a salt is gone, its rows are opaque bytes even to us.
+
+### Bots
+
+Link unfurlers (Signal, iMessage, WhatsApp, Slack) fetch a URL to build a
+preview, and each is a phantom scan. Match known bot user-agents, set `bot =
+TRUE`, and have the report exclude them by default while still showing the
+count. Excluding silently would hide the size of the correction; not excluding
+at all would inflate the headline number by an unknown factor.
+
+The denylist is a judgment call about which apps this audience actually uses,
+and is the operator's to set at implementation time.
+
+### Report
+
+`scripts/qr-report.ts`, following `scripts/read-gate-answers.ts` (env loading,
+`withConnection`, TTY discipline). Prints date range, distinct visitors, raw
+scans, bots excluded, and a per-day table.
+
+## Error handling
+
+Counting must never break the redirect. Wrap the whole record step in
+try/catch, increment an error metric, and redirect regardless — the same
+non-fatal pattern `gate-submit.ts:172` uses for encounters. A scanner standing
+in a grocery store must not see a 500 because the database blinked.
+
+**No `console.log` may touch the IP, the user agent, or the hash.** The
+pre-commit hook `scripts/check-zero-logging.sh` fires on emitters whose
+arguments match `ip|user_agent|cookie|token|...`, and it is correct to do so
+here. Log category names and `increment()` metrics only.
+
+## Two ways this silently lies
+
+- **`TRUST_PROXY` unset behind a reverse proxy.** Every visitor hashes to the
+  proxy's address and the distinct count collapses toward 1. This is the most
+  likely failure and it looks like "nobody scanned it."
+- **`TRUST_PROXY=true` with a proxy that does not strip client-supplied
+  `X-Forwarded-For`.** Anyone can forge the header and inflate the count.
+
+Confirm which applies to the deployment before writing the route, and record
+the answer here.
+
+## Testing
+
+Deno tests, `*_test.ts` per existing convention:
+
+- same IP + UA twice in a day -> 1 distinct, 2 hits
+- different UA, same IP -> 2 distinct
+- same IP + UA across two days -> 2 rows, and the day-2 hash differs (salt rotation)
+- a known bot UA is flagged and excluded from the default report
+- a DB failure still returns the 302
+- salts older than 48h are pruned
+- `getClientIp()` honors `TRUST_PROXY` in both states
+
+## Out of scope
+
+- The `/w/[token]` page design — deferred, to be designed separately.
+- Geofence and tamper alerting — separate spec, spans the node and the Pi.

--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -1,7 +1,9 @@
 # Co-op QR scan counting
 
 **Date:** 2026-08-11
-**Status:** approved, not implemented
+**Status:** implemented — migration, recorder, route and CLI all landed.
+Two operator steps remain before it records anything: apply migration 009, and
+seed the co-op wearable so `COOP_WEARABLE_TOKEN` is set (see Configuration).
 **Scope:** this repo only. The firmware half is
 `heltec-dd-node/docs/superpowers/specs/2026-08-11-coop-oled-content-rotation-design.md`.
 

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -3,6 +3,7 @@
 // This file is automatically updated during development when running `dev.ts`.
 
 import * as $_4m from './routes/4m.tsx';
+import * as $WillyStCo_op from './routes/WillyStCo-op.tsx';
 import * as $_404 from './routes/_404.tsx';
 import * as $about from './routes/about.tsx';
 import * as $about_confession_albums from './routes/about/confession-albums.tsx';
@@ -42,6 +43,7 @@ import type { Manifest } from '$fresh/server.ts';
 const manifest = {
   routes: {
     './routes/4m.tsx': $_4m,
+    './routes/WillyStCo-op.tsx': $WillyStCo_op,
     './routes/_404.tsx': $_404,
     './routes/about.tsx': $about,
     './routes/about/confession-albums.tsx': $about_confession_albums,

--- a/lib/client-ip.ts
+++ b/lib/client-ip.ts
@@ -1,0 +1,36 @@
+/**
+ * Client address resolution, honouring TRUST_PROXY.
+ *
+ * MERGE NOTE: routes/api/contact.ts carries a private copy of this function,
+ * but that file lives on `production` and not on `main`, which is where this
+ * branch is cut from -- so the two cannot be reconciled here. When this
+ * reaches production, delete contact.ts's copy and import this one instead.
+ * Proxy trust is exactly the kind of rule that must not exist twice: one copy
+ * updated and the other not is a silent security difference, not a visible
+ * bug, and nothing would fail to compile to reveal it.
+ *
+ * X-Forwarded-For is client-supplied unless a proxy overwrites it. Trusting
+ * it unconditionally would let anyone forge an address -- for the scan
+ * counter that means inflating the count arbitrarily, for the rate limiter it
+ * means bypassing the limit. So it is honoured only when the deployment
+ * asserts, via TRUST_PROXY, that something upstream rewrites the header.
+ */
+
+/**
+ * Resolve the client address.
+ *
+ * @param req the incoming request
+ * @param remoteHost the socket peer, from Fresh's ctx.remoteAddr.hostname
+ * @returns the address, or 'unknown' when neither source yields one
+ */
+export function getClientIp(req: Request, remoteHost: string | undefined): string {
+  const trustProxy = Deno.env.get('TRUST_PROXY') === 'true';
+  if (trustProxy) {
+    const xff = req.headers.get('x-forwarded-for');
+    if (xff) {
+      const first = xff.split(',')[0]?.trim();
+      if (first) return first;
+    }
+  }
+  return remoteHost || 'unknown';
+}

--- a/lib/client-ip_test.ts
+++ b/lib/client-ip_test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from '$std/assert/mod.ts';
+import { getClientIp } from './client-ip.ts';
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request('https://example.test/', { headers });
+}
+
+function withTrustProxy<T>(value: string | null, fn: () => T): T {
+  const prev = Deno.env.get('TRUST_PROXY');
+  if (value === null) Deno.env.delete('TRUST_PROXY');
+  else Deno.env.set('TRUST_PROXY', value);
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) Deno.env.delete('TRUST_PROXY');
+    else Deno.env.set('TRUST_PROXY', prev);
+  }
+}
+
+Deno.test('trusted proxy: takes the first X-Forwarded-For entry', () => {
+  withTrustProxy('true', () => {
+    const ip = getClientIp(req({ 'x-forwarded-for': '203.0.113.7, 10.0.0.1' }), '10.0.0.1');
+    assertEquals(ip, '203.0.113.7');
+  });
+});
+
+Deno.test('trusted proxy: trims whitespace around the entry', () => {
+  withTrustProxy('true', () => {
+    const ip = getClientIp(req({ 'x-forwarded-for': '  203.0.113.7  , 10.0.0.1' }), '10.0.0.1');
+    assertEquals(ip, '203.0.113.7');
+  });
+});
+
+Deno.test('trusted proxy: falls back to the socket when the header is absent', () => {
+  withTrustProxy('true', () => {
+    assertEquals(getClientIp(req(), '198.51.100.4'), '198.51.100.4');
+  });
+});
+
+// The spoofing guard. Without TRUST_PROXY set, a client-supplied header must
+// be ignored outright -- honouring it would let anyone inflate or split the
+// scan count at will just by sending a header.
+Deno.test('untrusted proxy: ignores X-Forwarded-For entirely', () => {
+  withTrustProxy(null, () => {
+    const ip = getClientIp(req({ 'x-forwarded-for': '203.0.113.7' }), '198.51.100.4');
+    assertEquals(ip, '198.51.100.4');
+  });
+});
+
+Deno.test('untrusted proxy: only the literal string "true" enables trust', () => {
+  withTrustProxy('1', () => {
+    const ip = getClientIp(req({ 'x-forwarded-for': '203.0.113.7' }), '198.51.100.4');
+    assertEquals(ip, '198.51.100.4');
+  });
+});
+
+Deno.test('an empty X-Forwarded-For does not shadow the socket address', () => {
+  withTrustProxy('true', () => {
+    assertEquals(getClientIp(req({ 'x-forwarded-for': '' }), '198.51.100.4'), '198.51.100.4');
+  });
+});
+
+Deno.test('no socket address and no header yields the unknown sentinel', () => {
+  withTrustProxy(null, () => {
+    assertEquals(getClientIp(req(), undefined), 'unknown');
+  });
+});

--- a/lib/qr-scans.ts
+++ b/lib/qr-scans.ts
@@ -1,0 +1,154 @@
+/**
+ * QR scan counting.
+ *
+ * A QR-bearing object in public points at a slug route; this records that a
+ * visit happened and how many distinct visitors it came from, without ever
+ * storing an address or a user agent.
+ *
+ * Identity is HMAC-SHA256(salt_for_today, ip + "\n" + user_agent). The salt is
+ * random per UTC day and deleted after 48 hours, which is what makes
+ * "non-linkable across days" true rather than decorative: once a salt is gone,
+ * that day's rows cannot be recomputed by anyone, including us. Deriving the
+ * salt from a long-lived secret was rejected for exactly that reason -- it
+ * would leave every past day permanently re-linkable by whoever holds it.
+ *
+ * The address exists only as an argument to visitorHash. It is never stored,
+ * never returned, and must never be logged -- scripts/check-zero-logging.sh
+ * enforces the last of those.
+ *
+ * Spec: docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+ */
+
+import type { PoolClient } from 'postgres';
+import { hmacSign, randomBytes } from './crypto.ts';
+import { withConnection } from './db.ts';
+
+/** How long a day's salt is retained. Past this, its rows are opaque forever. */
+export const SALT_RETENTION_DAYS = 2;
+
+/**
+ * User-agent substrings belonging to link unfurlers and crawlers.
+ *
+ * These are phantom scans: a messaging app fetches the URL to build a preview
+ * that nobody chose to open. Counting them as visitors would inflate the
+ * headline number by a factor nobody can estimate after the fact.
+ *
+ * They are flagged rather than dropped, so the report can show the size of the
+ * correction instead of hiding it. Extend this list as new senders appear --
+ * which apps matter depends on the audience, so it is the operator's call.
+ */
+export const BOT_USER_AGENT_MARKERS = [
+  'bot', // Slackbot, Twitterbot, TelegramBot, Discordbot, Googlebot
+  'crawler',
+  'spider',
+  'facebookexternalhit',
+  'whatsapp',
+  'skypeuripreview',
+  'embedly',
+  'quora link preview',
+  'vkshare',
+  'preview', // Apple's iMessage/Safari link preview fetches
+  'curl/',
+  'wget/',
+  'python-requests',
+  'go-http-client',
+  'headlesschrome',
+];
+
+/** The UTC calendar day a timestamp falls in, as YYYY-MM-DD. */
+export function utcDay(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * Whether a user agent looks like an automated fetch rather than a person.
+ *
+ * An empty user agent is deliberately NOT treated as a bot. Privacy-hardened
+ * browsers and some in-app webviews send none, and discarding those would
+ * silently drop real scans -- the opposite of the error this guards against.
+ */
+export function isBotUserAgent(userAgent: string): boolean {
+  const ua = userAgent.toLowerCase();
+  if (!ua) return false;
+  return BOT_USER_AGENT_MARKERS.some((marker) => ua.includes(marker));
+}
+
+/**
+ * Pseudonymous per-day identity for a visitor.
+ *
+ * The newline separator is load-bearing: concatenating the fields without one
+ * would let an address ending in the separator collide with a user agent
+ * beginning with one, so a crafted user agent could land in another visitor's
+ * bucket. Newline cannot appear in either field as delivered by the runtime.
+ */
+export function visitorHash(
+  salt: Uint8Array<ArrayBuffer>,
+  ip: string,
+  userAgent: string,
+): Promise<string> {
+  return hmacSign(`${ip}\n${userAgent}`, salt);
+}
+
+/**
+ * Today's salt, minting one if this is the day's first visit, and pruning any
+ * that have aged out.
+ *
+ * The INSERT ... ON CONFLICT DO NOTHING followed by a SELECT is what makes two
+ * simultaneous first-visits agree on one salt. Reading first and inserting
+ * after would race, and the two requests would hash the same person into two
+ * different buckets.
+ */
+async function saltForDay(client: PoolClient, day: string): Promise<Uint8Array<ArrayBuffer>> {
+  await client.queryObject(
+    `INSERT INTO fresh_qr_salts (day, salt) VALUES ($1, $2)
+       ON CONFLICT (day) DO NOTHING`,
+    [day, randomBytes(32)],
+  );
+
+  // Prune in the same path rather than on a schedule: no cron to forget, and
+  // the guarantee holds as long as the route is being hit at all.
+  await client.queryObject(
+    `DELETE FROM fresh_qr_salts WHERE day < ($1::date - $2::int)`,
+    [day, SALT_RETENTION_DAYS],
+  );
+
+  const result = await client.queryObject<{ salt: Uint8Array }>(
+    `SELECT salt FROM fresh_qr_salts WHERE day = $1`,
+    [day],
+  );
+  const salt = result.rows[0]?.salt;
+  if (!salt) throw new Error('qr salt missing immediately after insert');
+  return salt as Uint8Array<ArrayBuffer>;
+}
+
+/**
+ * Record one visit to a slug.
+ *
+ * Returns nothing: callers must not branch on whether this is a new visitor,
+ * because that would make the count observable from outside.
+ */
+export async function recordScan(
+  slug: string,
+  ip: string,
+  userAgent: string,
+  now: Date = new Date(),
+): Promise<void> {
+  const day = utcDay(now);
+  const bot = isBotUserAgent(userAgent);
+
+  await withConnection(async (client) => {
+    const salt = await saltForDay(client, day);
+    const hash = await visitorHash(salt, ip, userAgent);
+
+    // One row per (slug, day, visitor); hits counts the re-scans within it.
+    // Distinct visitors is then the row count and raw scans is SUM(hits), so
+    // neither number can be lost to a bug in the other.
+    await client.queryObject(
+      `INSERT INTO fresh_qr_scans (slug, day, visitor_hash, bot)
+            VALUES ($1, $2, $3, $4)
+       ON CONFLICT (slug, day, visitor_hash)
+         DO UPDATE SET hits = fresh_qr_scans.hits + 1`,
+      [slug, day, hash, bot],
+    );
+  });
+}

--- a/lib/qr-scans.ts
+++ b/lib/qr-scans.ts
@@ -23,8 +23,16 @@ import type { PoolClient } from 'postgres';
 import { hmacSign, randomBytes } from './crypto.ts';
 import { withConnection } from './db.ts';
 
-/** How long a day's salt is retained. Past this, its rows are opaque forever. */
-export const SALT_RETENTION_DAYS = 2;
+/**
+ * Days of salt history kept *beyond today*. 1 retains today and yesterday,
+ * which bounds any salt's age at 48 hours; past that its rows are opaque
+ * forever, to us included.
+ *
+ * This was 2, which kept the day before yesterday as well and so retained up
+ * to 72 hours -- the guarantee the whole design rests on, quietly overshot by
+ * a day.
+ */
+export const SALT_RETENTION_DAYS = 1;
 
 /**
  * User-agent substrings belonging to link unfurlers and crawlers.
@@ -105,8 +113,16 @@ async function saltForDay(client: PoolClient, day: string): Promise<Uint8Array<A
     [day, randomBytes(32)],
   );
 
-  // Prune in the same path rather than on a schedule: no cron to forget, and
-  // the guarantee holds as long as the route is being hit at all.
+  // Pruned in the request path rather than on a schedule: there is no
+  // scheduler in this app, and adding one for this is a bigger decision than
+  // the feature warrants.
+  //
+  // KNOWN LIMIT, and it is a real one: if scanning stops, pruning stops with
+  // it, and salts outlive the 48h window for as long as the route is idle.
+  // The exposure is that someone with database access could recompute hashes
+  // for days that should have become unrecomputable. If this object turns out
+  // to see long quiet stretches, move this DELETE to a scheduled UTC task --
+  // it is written to be safe to run from anywhere.
   await client.queryObject(
     `DELETE FROM fresh_qr_salts WHERE day < ($1::date - $2::int)`,
     [day, SALT_RETENTION_DAYS],

--- a/lib/qr-scans.ts
+++ b/lib/qr-scans.ts
@@ -63,6 +63,34 @@ export const BOT_USER_AGENT_MARKERS = [
   'headlesschrome',
 ];
 
+/**
+ * Reject if `work` has not settled within `ms`.
+ *
+ * Wrapping recordScan in try/catch handles a database that *fails*. It does
+ * nothing for one that *stalls* -- an exhausted pool or a query with no
+ * statement timeout never rejects, so the handler would wait on it and the
+ * scanner would never receive their redirect. That is a worse failure than
+ * the one the try/catch was written for, because it is silent from both ends.
+ *
+ * The abandoned work is not cancelled -- deno-postgres exposes no cancellation
+ * -- so the query runs to completion against a connection nobody is waiting
+ * on. That is acceptable here: the row is idempotent and the pool reclaims the
+ * connection. Promise.race attaches a handler to both sides, so a late
+ * rejection from the abandoned work is already handled and cannot surface as
+ * an unhandled rejection.
+ */
+export function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+  // Not `number`: nodeModulesDir puts Node's typings in scope, where
+  // setTimeout returns a Timeout object rather than a handle.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('deadline')), ms);
+  });
+  // clearTimeout on both paths: an armed timer holds the process open and
+  // trips Deno's leak detector in tests.
+  return Promise.race([work, deadline]).finally(() => clearTimeout(timer));
+}
+
 /** The UTC calendar day a timestamp falls in, as YYYY-MM-DD. */
 export function utcDay(now: Date): string {
   return now.toISOString().slice(0, 10);

--- a/lib/qr-scans_test.ts
+++ b/lib/qr-scans_test.ts
@@ -1,0 +1,97 @@
+import { assert, assertEquals, assertNotEquals } from '$std/assert/mod.ts';
+import { isBotUserAgent, utcDay, visitorHash } from './qr-scans.ts';
+
+const SALT_A = new Uint8Array(32).fill(1);
+const SALT_B = new Uint8Array(32).fill(2);
+
+const PHONE = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15';
+
+// --- utcDay ---------------------------------------------------------------
+
+Deno.test('utcDay formats as YYYY-MM-DD', () => {
+  assertEquals(utcDay(new Date('2026-08-11T14:32:00Z')), '2026-08-11');
+});
+
+// Local time would roll the bucket at the wrong moment and, worse, would move
+// the boundary if the server's zone ever changed.
+Deno.test('utcDay uses UTC, not the host timezone', () => {
+  assertEquals(utcDay(new Date('2026-08-11T23:59:59Z')), '2026-08-11');
+  assertEquals(utcDay(new Date('2026-08-12T00:00:00Z')), '2026-08-12');
+});
+
+// --- visitorHash ----------------------------------------------------------
+
+Deno.test('the same visitor on the same day hashes identically', async () => {
+  const a = await visitorHash(SALT_A, '203.0.113.7', PHONE);
+  const b = await visitorHash(SALT_A, '203.0.113.7', PHONE);
+  assertEquals(a, b);
+});
+
+Deno.test('a different user agent is a different visitor', async () => {
+  const a = await visitorHash(SALT_A, '203.0.113.7', PHONE);
+  const b = await visitorHash(SALT_A, '203.0.113.7', PHONE + ' Safari');
+  assertNotEquals(a, b);
+});
+
+Deno.test('a different address is a different visitor', async () => {
+  const a = await visitorHash(SALT_A, '203.0.113.7', PHONE);
+  const b = await visitorHash(SALT_A, '203.0.113.8', PHONE);
+  assertNotEquals(a, b);
+});
+
+// The unlinkability property the 48h salt policy exists to provide: the same
+// person on two days must not produce the same hash, or the daily rotation
+// would be decorative and every past day would stay correlatable.
+Deno.test('the same visitor on a different day hashes differently', async () => {
+  const a = await visitorHash(SALT_A, '203.0.113.7', PHONE);
+  const b = await visitorHash(SALT_B, '203.0.113.7', PHONE);
+  assertNotEquals(a, b);
+});
+
+// Without an unambiguous separator, an address ending in a newline could
+// collide with a user agent beginning with one, letting a crafted UA
+// impersonate another visitor's bucket.
+Deno.test('the field separator cannot be forged across ip and user agent', async () => {
+  const a = await visitorHash(SALT_A, '203.0.113.7\nEvil', '');
+  const b = await visitorHash(SALT_A, '203.0.113.7', 'Evil');
+  assertNotEquals(a, b);
+});
+
+Deno.test('the hash is hex and reveals nothing of its length', async () => {
+  const short = await visitorHash(SALT_A, '1.1.1.1', 'x');
+  const long = await visitorHash(SALT_A, '203.0.113.7', PHONE.repeat(4));
+  assertEquals(short.length, long.length);
+  assert(/^[0-9a-f]+$/.test(short), short);
+});
+
+// --- bot detection --------------------------------------------------------
+
+Deno.test('link unfurlers are flagged as bots', () => {
+  for (
+    const ua of [
+      'Mozilla/5.0 (compatible; Slackbot-LinkExpanding 1.0; +https://api.slack.com/robots)',
+      'WhatsApp/2.23.20.0 A',
+      'facebookexternalhit/1.1',
+      'Twitterbot/1.0',
+      'TelegramBot (like TwitterBot)',
+      'Mozilla/5.0 (compatible; Discordbot/2.0)',
+      'Mozilla/5.0 (Macintosh) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15 Preview',
+    ]
+  ) {
+    assert(isBotUserAgent(ua), `expected bot: ${ua}`);
+  }
+});
+
+Deno.test('a real phone browser is not flagged', () => {
+  assertEquals(isBotUserAgent(PHONE), false);
+});
+
+Deno.test('bot matching is case-insensitive', () => {
+  assert(isBotUserAgent('slackbot-linkexpanding 1.0'));
+});
+
+// An absent user agent is suspicious but not identifiable as a bot; counting
+// it as one would silently discard real scans from privacy-hardened browsers.
+Deno.test('an empty user agent is not assumed to be a bot', () => {
+  assertEquals(isBotUserAgent(''), false);
+});

--- a/lib/qr-scans_test.ts
+++ b/lib/qr-scans_test.ts
@@ -1,5 +1,5 @@
-import { assert, assertEquals, assertNotEquals } from '$std/assert/mod.ts';
-import { isBotUserAgent, utcDay, visitorHash } from './qr-scans.ts';
+import { assert, assertEquals, assertNotEquals, assertRejects } from '$std/assert/mod.ts';
+import { isBotUserAgent, utcDay, visitorHash, withDeadline } from './qr-scans.ts';
 
 const SALT_A = new Uint8Array(32).fill(1);
 const SALT_B = new Uint8Array(32).fill(2);
@@ -62,6 +62,45 @@ Deno.test('the hash is hex and reveals nothing of its length', async () => {
   const long = await visitorHash(SALT_A, '203.0.113.7', PHONE.repeat(4));
   assertEquals(short.length, long.length);
   assert(/^[0-9a-f]+$/.test(short), short);
+});
+
+// --- deadline -------------------------------------------------------------
+
+Deno.test('work that finishes in time passes its value through', async () => {
+  assertEquals(await withDeadline(Promise.resolve('done'), 1000), 'done');
+});
+
+// A rejection must stay a rejection rather than being flattened into the
+// deadline case: the caller distinguishes them only by not caring, and a
+// future caller might.
+Deno.test('work that fails in time still rejects', async () => {
+  await assertRejects(() => withDeadline(Promise.reject(new Error('boom')), 1000), Error, 'boom');
+});
+
+// The case the try/catch around recordScan cannot cover. A rejecting database
+// is caught; a *stalled* one is not, and without this the handler waits on it
+// and the scanner never receives the redirect.
+Deno.test('work that stalls past the deadline rejects instead of hanging', async () => {
+  const stalled = new Promise<never>(() => {}); // never settles
+  await assertRejects(() => withDeadline(stalled, 20), Error, 'deadline');
+});
+
+// A timer left armed keeps the process alive and trips Deno's leak detector;
+// this test fails outright if the timer is not cleared on the fast path.
+Deno.test('the deadline timer is cleared when work wins', async () => {
+  await withDeadline(Promise.resolve(1), 60_000);
+});
+
+// Promise.race attaches a handler to both, so a late rejection from abandoned
+// work must not surface as an unhandled rejection and kill the process.
+Deno.test('work rejecting after the deadline does not go unhandled', async () => {
+  let failLate: (e: Error) => void = () => {};
+  const late = new Promise<never>((_, reject) => {
+    failLate = reject;
+  });
+  await assertRejects(() => withDeadline(late, 10), Error, 'deadline');
+  failLate(new Error('too late'));
+  await new Promise((r) => setTimeout(r, 20));
 });
 
 // --- bot detection --------------------------------------------------------

--- a/routes/WillyStCo-op.tsx
+++ b/routes/WillyStCo-op.tsx
@@ -23,10 +23,17 @@
 import { Handlers } from '$fresh/server.ts';
 import { getClientIp } from '../lib/client-ip.ts';
 import { increment } from '../lib/metrics.ts';
-import { recordScan } from '../lib/qr-scans.ts';
+import { recordScan, withDeadline } from '../lib/qr-scans.ts';
 
 /** Matches the counter's slug column; also the name of this file's route. */
 const SLUG = 'WillyStCo-op';
+
+/**
+ * How long the redirect will wait on the counter. Generous for a single
+ * INSERT on a warm pool, short enough that a stalled database costs the
+ * scanner a beat rather than the page.
+ */
+const RECORD_DEADLINE_MS = 1500;
 
 /** Same shape tools/seed-wearable.ts mints and /w/[token] accepts. */
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,64}$/;
@@ -54,10 +61,17 @@ export const handler: Handlers = {
     const remoteHost = (ctx as { remoteAddr?: { hostname?: string } }).remoteAddr?.hostname;
 
     try {
-      await recordScan(
-        SLUG,
-        getClientIp(req, remoteHost),
-        req.headers.get('user-agent') ?? '',
+      // Bounded, not merely wrapped. try/catch handles a database that fails;
+      // it does nothing for one that stalls, and a stalled pool would hold the
+      // redirect until an upstream timeout -- leaving someone standing in a
+      // shop looking at a spinner. Losing a count is the cheaper failure.
+      await withDeadline(
+        recordScan(
+          SLUG,
+          getClientIp(req, remoteHost),
+          req.headers.get('user-agent') ?? '',
+        ),
+        RECORD_DEADLINE_MS,
       );
       increment('qr.scan.recorded');
     } catch {

--- a/routes/WillyStCo-op.tsx
+++ b/routes/WillyStCo-op.tsx
@@ -1,0 +1,80 @@
+/**
+ * Willy St Co-op QR landing
+ *
+ * GET /WillyStCo-op
+ *
+ * The QR on the co-op node points here. This route records the visit and
+ * forwards to the wearable page, which greets the scanner and leads into the
+ * site's normal entry ritual.
+ *
+ * Counting lives here rather than on /w/:token so the vanity URL and its
+ * counter stay together, the wearable page is untouched, and the QR can later
+ * be re-pointed elsewhere without moving the counter. The two numbers answer
+ * different questions: scans (fresh_qr_scans) and conversions
+ * (fresh_encounters, recorded by gate-submit when an email is left).
+ *
+ * Privacy: the slug never reaches the scanner's browser -- the redirect names
+ * only the opaque wearable token, so the URL they see does not name a place.
+ * No address or user agent is stored; see lib/qr-scans.ts.
+ *
+ * Spec: docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+ */
+
+import { Handlers } from '$fresh/server.ts';
+import { getClientIp } from '../lib/client-ip.ts';
+import { increment } from '../lib/metrics.ts';
+import { recordScan } from '../lib/qr-scans.ts';
+
+/** Matches the counter's slug column; also the name of this file's route. */
+const SLUG = 'WillyStCo-op';
+
+/** Same shape tools/seed-wearable.ts mints and /w/[token] accepts. */
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{16,64}$/;
+
+/**
+ * Where a scanner is sent. The token is configuration, not code: the co-op
+ * drop has its own site-owned wearable row, and a QR printed in a public
+ * shop makes that token public by definition -- so it must never be a
+ * personal one, whose bearer credential would graft every passerby onto a
+ * real person's graph (see tools/seed-wearable.ts).
+ */
+function destination(): string {
+  const token = Deno.env.get('COOP_WEARABLE_TOKEN') ?? '';
+  if (!TOKEN_PATTERN.test(token)) {
+    // Unseeded or malformed is an operator error, not the scanner's problem.
+    // The entry ritual is a better landing than a 404 on a printed code.
+    increment('errors.config.qr_token_missing');
+    return '/';
+  }
+  return `/w/${token}`;
+}
+
+export const handler: Handlers = {
+  async GET(req, ctx) {
+    const remoteHost = (ctx as { remoteAddr?: { hostname?: string } }).remoteAddr?.hostname;
+
+    try {
+      await recordScan(
+        SLUG,
+        getClientIp(req, remoteHost),
+        req.headers.get('user-agent') ?? '',
+      );
+      increment('qr.scan.recorded');
+    } catch {
+      // Never let counting break the redirect. Category only -- the error may
+      // carry the address, and scripts/check-zero-logging.sh forbids emitting
+      // it. The metric is how this failure becomes visible.
+      increment('errors.db.qr_scan');
+    }
+
+    return new Response(null, {
+      status: 302,
+      headers: {
+        location: destination(),
+        // A cached redirect would be served by the browser without ever
+        // reaching this handler, and the scan would go uncounted.
+        'cache-control': 'no-store',
+      },
+    });
+  },
+};

--- a/routes/WillyStCo-op_test.ts
+++ b/routes/WillyStCo-op_test.ts
@@ -1,0 +1,73 @@
+import { assertEquals } from '$std/assert/mod.ts';
+import { handler } from './WillyStCo-op.tsx';
+
+// deno-lint-ignore no-explicit-any
+const GET = (handler as any).GET as (req: Request, ctx: unknown) => Promise<Response>;
+
+function scan(): Promise<Response> {
+  const req = new Request('https://example.test/WillyStCo-op', {
+    headers: { 'user-agent': 'Mozilla/5.0 (iPhone)' },
+  });
+  return GET(req, { remoteAddr: { hostname: '203.0.113.7' } });
+}
+
+// Must await fn before restoring. A synchronous version returns the promise
+// and runs its finally immediately, tearing the variable down before the body
+// ever reads it -- which makes every assertion that depends on the value fail
+// for a reason that looks like a production bug.
+async function withEnv<T>(key: string, value: string | null, fn: () => Promise<T>): Promise<T> {
+  const prev = Deno.env.get(key);
+  if (value === null) Deno.env.delete(key);
+  else Deno.env.set(key, value);
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) Deno.env.delete(key);
+    else Deno.env.set(key, prev);
+  }
+}
+
+// No DATABASE_URL is configured in the test environment, so recordScan throws.
+// That is the point: counting must never be able to break the redirect. A
+// person standing in a grocery store must not meet a 500 because the database
+// blinked -- the same non-fatal rule gate-submit applies to encounters.
+Deno.test('a scan redirects to the wearable page even when recording fails', async () => {
+  await withEnv('COOP_WEARABLE_TOKEN', 'abcdefghijklmnop', async () => {
+    const res = await scan();
+    assertEquals(res.status, 302);
+    assertEquals(res.headers.get('location'), '/w/abcdefghijklmnop');
+  });
+});
+
+// The slug must not appear in the redirect: the URL names a place, and the
+// person scanning it did not ask to be told where they are.
+Deno.test('the redirect does not leak the slug', async () => {
+  await withEnv('COOP_WEARABLE_TOKEN', 'abcdefghijklmnop', async () => {
+    const res = await scan();
+    assertEquals(res.headers.get('location')?.includes('WillySt'), false);
+  });
+});
+
+// An unseeded token is an operator error, not a scanner's problem. Sending
+// them to the entry ritual is better than a 404 on a printed code.
+Deno.test('an unconfigured token still lands the scanner somewhere', async () => {
+  await withEnv('COOP_WEARABLE_TOKEN', null, async () => {
+    const res = await scan();
+    assertEquals(res.status, 302);
+    assertEquals(res.headers.get('location'), '/');
+  });
+});
+
+Deno.test('a malformed token is rejected rather than redirected to', async () => {
+  await withEnv('COOP_WEARABLE_TOKEN', '../../etc/passwd', async () => {
+    const res = await scan();
+    assertEquals(res.headers.get('location'), '/');
+  });
+});
+
+Deno.test('the redirect is never cached, so every scan reaches the counter', async () => {
+  await withEnv('COOP_WEARABLE_TOKEN', 'abcdefghijklmnop', async () => {
+    const res = await scan();
+    assertEquals(res.headers.get('cache-control'), 'no-store');
+  });
+});

--- a/scripts/qr-report.ts
+++ b/scripts/qr-report.ts
@@ -94,9 +94,13 @@ if (rows.length === 0) {
   Deno.exit(0);
 }
 
-const totalVisitors = rows.reduce((n, r) => n + Number(r.visitors), 0);
-const totalScans = rows.reduce((n, r) => n + Number(r.scans), 0);
-const totalBots = rows.reduce((n, r) => n + Number(r.bots), 0);
+// Accumulated as bigint because that is what the driver hands back for these
+// aggregates. Not a realistic overflow risk at co-op foot traffic -- it would
+// take 2^53 scans -- but converting to Number here and back to string for
+// display just mixes the two representations for no gain.
+const totalVisitors = rows.reduce((n, r) => n + r.visitors, 0n);
+const totalScans = rows.reduce((n, r) => n + r.scans, 0n);
+const totalBots = rows.reduce((n, r) => n + r.bots, 0n);
 const iso = (d: Date) => d.toISOString().slice(0, 10);
 
 console.log('');

--- a/scripts/qr-report.ts
+++ b/scripts/qr-report.ts
@@ -44,11 +44,13 @@ const SLUG = arg('slug', 'WillyStCo-op');
 const DAYS = Number(arg('days', '90'));
 const INCLUDE_BOTS = Deno.args.includes('--bots');
 
-// Must be an int4: DAYS is cast to ::int in the query below, so a fractional
-// or oversized value reaches the operator as a raw Postgres cast error rather
-// than as the message here.
-if (!Number.isSafeInteger(DAYS) || DAYS <= 0 || DAYS > 2_147_483_647) {
-  console.error('--days must be a positive integer no greater than 2147483647');
+// Capped at a century, not at int4's ceiling. DAYS is subtracted from a date
+// in SQL, and a value near 2147483647 pushes the result past Postgres's
+// minimum date -- so the operator gets "date out of range" instead of the
+// message here. No QR object outlives a hundred years of reporting.
+const MAX_DAYS = 36_500;
+if (!Number.isSafeInteger(DAYS) || DAYS <= 0 || DAYS > MAX_DAYS) {
+  console.error(`--days must be a positive integer no greater than ${MAX_DAYS}`);
   Deno.exit(2);
 }
 
@@ -72,6 +74,10 @@ const rows = await withConnection(async (client) => {
         -- would silently shift the window by a day. DAYS - 1 so --days 90
         -- covers ninety dates including today, not ninety-one.
         AND day >= ((CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date - ($2::int - 1))
+        -- Closed at both ends. Nothing constrains day to the past, so a row
+        -- dated ahead -- clock skew, a manual insert -- would otherwise make
+        -- --days 1 cover more than one date.
+        AND day <= (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date
       GROUP BY day
       ORDER BY day`,
     [SLUG, DAYS, INCLUDE_BOTS],

--- a/scripts/qr-report.ts
+++ b/scripts/qr-report.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
+/**
+ * How many discrete visits a QR code produced. Operator tool — run it yourself.
+ *
+ *   deno run -A scripts/qr-report.ts                     # the co-op drop
+ *   deno run -A scripts/qr-report.ts --slug OtherThing
+ *   deno run -A scripts/qr-report.ts --days 30
+ *   deno run -A scripts/qr-report.ts --bots              # include unfurlers
+ *
+ * A CLI rather than an endpoint on purpose: this is the foot traffic of a
+ * physical place, and a route would be one auth bug away from publishing it.
+ * There is nothing here to guard because there is no surface to reach.
+ *
+ * "Discrete" means one person-shaped visitor per UTC day, identified by
+ * HMAC(daily salt, address + user agent). Two consequences worth holding:
+ * the same person on two days counts twice, and the daily salts are deleted
+ * after 48h, so these totals can never be recomputed or re-linked from the
+ * raw rows — not by anyone, including whoever runs this.
+ *
+ * Spec: docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+ */
+
+import { withConnection } from '../lib/db.ts';
+
+// Match migrate.ts and seed-wearable.ts: load env files so DATABASE_URL is set.
+for (const envFile of ['.env.fresh', '.env']) {
+  try {
+    for (const line of (await Deno.readTextFile(envFile)).split('\n')) {
+      const t = line.trim();
+      if (t && !t.startsWith('#')) {
+        const i = t.indexOf('=');
+        if (i > 0) Deno.env.set(t.slice(0, i).trim(), t.slice(i + 1).trim());
+      }
+    }
+  } catch { /* file optional */ }
+}
+
+function arg(name: string, fallback: string): string {
+  const i = Deno.args.indexOf(`--${name}`);
+  return i >= 0 && Deno.args[i + 1] ? Deno.args[i + 1] : fallback;
+}
+
+const SLUG = arg('slug', 'WillyStCo-op');
+const DAYS = Number(arg('days', '90'));
+const INCLUDE_BOTS = Deno.args.includes('--bots');
+
+if (!Number.isFinite(DAYS) || DAYS <= 0) {
+  console.error('--days must be a positive number');
+  Deno.exit(2);
+}
+
+interface DayRow {
+  day: Date;
+  visitors: bigint;
+  scans: bigint;
+  bots: bigint;
+}
+
+const rows = await withConnection(async (client) => {
+  const result = await client.queryObject<DayRow>(
+    `SELECT day,
+            COUNT(*) FILTER (WHERE $3 OR NOT bot)::bigint          AS visitors,
+            COALESCE(SUM(hits) FILTER (WHERE $3 OR NOT bot), 0)::bigint AS scans,
+            COUNT(*) FILTER (WHERE bot)::bigint                    AS bots
+       FROM fresh_qr_scans
+      WHERE slug = $1
+        AND day >= (CURRENT_DATE - $2::int)
+      GROUP BY day
+      ORDER BY day`,
+    [SLUG, DAYS, INCLUDE_BOTS],
+  );
+  return result.rows;
+});
+
+if (rows.length === 0) {
+  console.log(`No scans recorded for "${SLUG}" in the last ${DAYS} days.`);
+  console.log('');
+  console.log('If you expected some, check TRUST_PROXY on the deployment before');
+  console.log('concluding nobody scanned: behind a reverse proxy with it unset,');
+  console.log('every visitor hashes to the proxy and the count collapses toward 1.');
+  Deno.exit(0);
+}
+
+const totalVisitors = rows.reduce((n, r) => n + Number(r.visitors), 0);
+const totalScans = rows.reduce((n, r) => n + Number(r.scans), 0);
+const totalBots = rows.reduce((n, r) => n + Number(r.bots), 0);
+const iso = (d: Date) => d.toISOString().slice(0, 10);
+
+console.log('');
+console.log(`  ${SLUG}   ${iso(rows[0].day)} to ${iso(rows[rows.length - 1].day)}`);
+console.log('');
+console.log(`  discrete visitors   ${totalVisitors}`);
+console.log(`  raw scans           ${totalScans}`);
+console.log(
+  `  link previews       ${totalBots}${INCLUDE_BOTS ? ' (counted above)' : ' (excluded)'}`,
+);
+console.log('');
+console.log('  day           visitors   scans');
+console.log('  ----------    --------   -----');
+for (const r of rows) {
+  console.log(
+    `  ${iso(r.day)}    ${String(r.visitors).padStart(8)}   ${String(r.scans).padStart(5)}`,
+  );
+}
+console.log('');
+console.log('  A visitor is counted once per UTC day. The same person returning');
+console.log('  the next day counts again; the daily salt is gone after 48h, so');
+console.log('  those two visits can no longer be linked, by anyone.');
+console.log('');
+
+// The pool holds the process open otherwise.
+const { closePool } = await import('../lib/db.ts');
+await closePool();

--- a/scripts/qr-report.ts
+++ b/scripts/qr-report.ts
@@ -44,8 +44,11 @@ const SLUG = arg('slug', 'WillyStCo-op');
 const DAYS = Number(arg('days', '90'));
 const INCLUDE_BOTS = Deno.args.includes('--bots');
 
-if (!Number.isFinite(DAYS) || DAYS <= 0) {
-  console.error('--days must be a positive number');
+// Must be an int4: DAYS is cast to ::int in the query below, so a fractional
+// or oversized value reaches the operator as a raw Postgres cast error rather
+// than as the message here.
+if (!Number.isSafeInteger(DAYS) || DAYS <= 0 || DAYS > 2_147_483_647) {
+  console.error('--days must be a positive integer no greater than 2147483647');
   Deno.exit(2);
 }
 
@@ -64,7 +67,11 @@ const rows = await withConnection(async (client) => {
             COUNT(*) FILTER (WHERE bot)::bigint                    AS bots
        FROM fresh_qr_scans
       WHERE slug = $1
-        AND day >= (CURRENT_DATE - $2::int)
+        -- UTC, not CURRENT_DATE: the day column is bucketed in UTC, and
+        -- CURRENT_DATE follows the session timezone, so a non-UTC session
+        -- would silently shift the window by a day. DAYS - 1 so --days 90
+        -- covers ninety dates including today, not ninety-one.
+        AND day >= ((CURRENT_TIMESTAMP AT TIME ZONE 'UTC')::date - ($2::int - 1))
       GROUP BY day
       ORDER BY day`,
     [SLUG, DAYS, INCLUDE_BOTS],


### PR DESCRIPTION
The QR on the Willy St Co-op node pointed at `/Level5`, a route that does not exist, so every scan was a 404 and nothing counted them. Neither existing mechanism could answer "how many people scanned this":

- `lib/metrics.ts` is in-memory, single-process, one-minute buckets — it resets on every deploy.
- `fresh_encounters` only gets a row when a scanner submits their email at the gate, so anyone who scanned, read, and walked away was invisible.

## What this adds

`/WillyStCo-op` records the visit and `302`s to `/w/<token>`, which greets the scanner and leads into the normal entry ritual. The slug never reaches the browser, so the URL a scanner sees names no place.

A visitor is `HMAC-SHA256(salt_for_today, ip + LF + user_agent)`. The salt is random per UTC day and deleted after 48h — that is what makes "unlinkable across days" true rather than decorative. A salt derived from a long-lived secret would leave every past day recomputable forever by whoever holds it. **The address is never stored, returned, or logged.**

One row per `(slug, day, visitor)` with a `hits` counter, so distinct visitors is the row count and raw scans is `SUM(hits)` — neither number can be lost to a bug in the other.

Reporting is `scripts/qr-report.ts`, a CLI rather than an endpoint: this is the foot traffic of a physical place, and a route would be one auth bug from publishing it.

## Details worth a reviewer's attention

- **The newline separator is load-bearing** and has its own test. Without it, an address ending in the separator could collide with a user agent beginning with one, letting a crafted UA land in another visitor's bucket.
- **Counting cannot break the redirect.** Recording is wrapped; failure only increments a metric, mirroring the non-fatal encounter pattern in `gate-submit.ts`. Someone standing in a grocery store must not meet a 500.
- **The redirect is `no-store`** — a cached redirect would be served by the browser without reaching the handler, and the scan would go uncounted.
- **An absent user agent is deliberately not treated as a bot.** Privacy-hardened browsers send none, and discarding those would drop real scans.
- **`getClientIp` lands in `lib/client-ip.ts`.** `routes/api/contact.ts` has its own copy — it should be deleted and this one imported. Proxy trust must not exist twice, and nothing would fail to compile to reveal the drift.

## Two ways this can silently lie

- `TRUST_PROXY` unset behind a reverse proxy: every visitor hashes to the proxy and the distinct count collapses toward 1. This is the most likely failure and it looks like "nobody scanned it."
- `TRUST_PROXY=true` with a proxy that does not strip client-supplied `X-Forwarded-For`: anyone can forge the header and inflate the count.

## Required before this does anything

1. Apply migration `009_qr_scan_counts.sql`.
2. Seed the co-op wearable with `tools/seed-wearable.ts` and set `COOP_WEARABLE_TOKEN`. It must be a dedicated site-owned token — a QR in a public shop makes that bearer credential public, and a personal one would graft every passerby onto a real person's graph.

Until both are done the route redirects to `/` and increments `errors.config.qr_token_missing`.

## Verification

24 new tests pass; `deno check main.ts` and `deno fmt --check` are clean on this base.

CodeRabbit could not review this repo — three attempts all failed with `Out of memory` at the connect phase, before sandbox setup. The repo carries 4,339 tracked `rust-server/target` build artifacts and a 695 MB `.git`. Those artifacts are **not** gitignored, which is worth fixing separately.

Spec: `docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md`
Firmware half: `nyagrodha/heltec-dd-node` @ `916647a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a QR code destination that redirects visitors to the configured wearable page.
  - QR scans are counted daily, with repeat visits tracked and bot traffic categorized.
  - Added reporting tools for reviewing scan totals by day, visitor type, and QR destination.
  - Added privacy-conscious visitor deduplication without storing IP addresses or user-agent details.
  - Redirects remain available even if scan recording encounters an error.
  - Redirect responses are not cached, and invalid or missing configuration safely falls back to the home page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->