### PR TITLE
Prune QR daily salts on a timer, not only when someone scans

### DIFF
--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -125,8 +125,9 @@ this machinery.
 On the first visit of a UTC day, generate 32 random bytes and
 `INSERT ... ON CONFLICT (day) DO NOTHING`, then `SELECT` the winner — the
 conflict path is what makes two simultaneous first-visits agree on one salt
-instead of racing. The same code path prunes:
-`DELETE FROM fresh_qr_salts WHERE day < CURRENT_DATE - 1`.
+instead of racing. That path also prunes opportunistically, using the same
+`SALT_PRUNE_SQL` (`DELETE FROM fresh_qr_salts WHERE day < $1`) the timer runs,
+parameterised with `saltCutoffDay()` — see "Pruning runs on a timer" below.
 
 Deriving the salt from a long-lived secret was rejected. `HMAC(SECRET, date)`
 is recomputable forever by anyone holding `SECRET`, so every past day stays

--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -133,13 +133,25 @@ is recomputable forever by anyone holding `SECRET`, so every past day stays
 re-linkable and the daily rotation is decorative. Random-and-deleted means that
 once a salt is gone, its rows are opaque bytes even to us.
 
-**Known limit on the 48h guarantee.** Pruning happens in the request path,
-because this app has no scheduler and adding one is a larger decision than the
-feature warrants. If scanning stops, pruning stops with it, and salts outlive
-the window for as long as the route is idle — so the guarantee is "48 hours,
-provided the object is being scanned", not unconditionally. If the co-op node
-turns out to see long quiet stretches, move the `DELETE` to a scheduled UTC
-task; it is written to be safe to run from anywhere.
+**Pruning runs on a timer, and also in the request path.**
+
+This was originally request-path only, on the reasoning that the app had no
+scheduler. That was wrong, and it failed in production within two days:
+on 2026-08-13 the **2026-08-11 salt was still present**, because nothing had
+visited `/WillyStCo-op` since Aug 11 — leaving those two visitors re-linkable
+past the window this design rests on. A quiet noticeboard is the normal case
+for a QR on a wall, not the edge case, so the condition that disables pruning
+is the same condition the feature operates under most of the time.
+
+`scripts/prune-qr-salts.ts` on a systemd timer is now what guarantees the
+window. The request-path prune is kept as well, deliberately: the two fail
+independently — a dead timer is covered by traffic, an idle URL is covered by
+the timer — and the cost is one indexed `DELETE` against a table holding at
+most two rows.
+
+The cutoff is computed in TypeScript from UTC (`saltCutoffDay`) rather than in
+SQL from `CURRENT_DATE`, which follows the database session's timezone and
+would shift the window by a day.
 
 ### Bots
 

--- a/lib/qr-scans.ts
+++ b/lib/qr-scans.ts
@@ -97,6 +97,20 @@ export function utcDay(now: Date): string {
 }
 
 /**
+ * Salts for days strictly before this are deleted. With SALT_RETENTION_DAYS=1
+ * that is yesterday, so today and yesterday survive and no salt outlives 48h.
+ *
+ * Derived in TypeScript from UTC rather than in SQL from CURRENT_DATE, which
+ * follows the database session's timezone and would shift the window by a day
+ * on a non-UTC session -- the same trap the report query hit.
+ */
+export function saltCutoffDay(now: Date): string {
+  const cutoff = new Date(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - SALT_RETENTION_DAYS);
+  return utcDay(cutoff);
+}
+
+/**
  * Whether a user agent looks like an automated fetch rather than a person.
  *
  * An empty user agent is deliberately NOT treated as a bot. Privacy-hardened
@@ -125,6 +139,29 @@ export function visitorHash(
   return hmacSign(`${ip}\n${userAgent}`, salt);
 }
 
+/** One definition of the prune, shared by the request path and the timer. */
+const SALT_PRUNE_SQL = `DELETE FROM fresh_qr_salts WHERE day < $1`;
+
+/**
+ * Delete every salt older than the retention window, on its own connection.
+ *
+ * This is the scheduled entry point (scripts/prune-qr-salts.ts). It exists
+ * because pruning inside the request path only runs while the object is being
+ * scanned -- and a quiet noticeboard is the normal case, not the edge case.
+ * Observed live: an Aug 11 salt was still present on Aug 13 because nothing
+ * had visited the route since, leaving those visitors re-linkable past the
+ * window the design promises.
+ *
+ * Returns the number of salts removed so the caller can report it.
+ */
+export async function pruneSalts(now: Date = new Date()): Promise<number> {
+  const cutoff = saltCutoffDay(now);
+  return await withConnection(async (client) => {
+    const result = await client.queryObject(SALT_PRUNE_SQL, [cutoff]);
+    return result.rowCount ?? 0;
+  });
+}
+
 /**
  * Today's salt, minting one if this is the day's first visit, and pruning any
  * that have aged out.
@@ -141,20 +178,15 @@ async function saltForDay(client: PoolClient, day: string): Promise<Uint8Array<A
     [day, randomBytes(32)],
   );
 
-  // Pruned in the request path rather than on a schedule: there is no
-  // scheduler in this app, and adding one for this is a bigger decision than
-  // the feature warrants.
+  // Opportunistic prune. scripts/prune-qr-salts.ts on a timer is what actually
+  // guarantees the window -- this one only helps while traffic exists, and
+  // that is exactly the condition under which it is not needed.
   //
-  // KNOWN LIMIT, and it is a real one: if scanning stops, pruning stops with
-  // it, and salts outlive the 48h window for as long as the route is idle.
-  // The exposure is that someone with database access could recompute hashes
-  // for days that should have become unrecomputable. If this object turns out
-  // to see long quiet stretches, move this DELETE to a scheduled UTC task --
-  // it is written to be safe to run from anywhere.
-  await client.queryObject(
-    `DELETE FROM fresh_qr_salts WHERE day < ($1::date - $2::int)`,
-    [day, SALT_RETENTION_DAYS],
-  );
+  // Kept anyway, deliberately: the two mechanisms fail independently. A dead
+  // timer is covered by traffic, an idle URL is covered by the timer, and the
+  // cost here is one indexed DELETE against a table that holds at most two
+  // rows. For a property the design rests on, that is worth paying twice.
+  await client.queryObject(SALT_PRUNE_SQL, [saltCutoffDay(new Date())]);
 
   const result = await client.queryObject<{ salt: Uint8Array }>(
     `SELECT salt FROM fresh_qr_salts WHERE day = $1`,

--- a/lib/qr-scans_test.ts
+++ b/lib/qr-scans_test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertNotEquals, assertRejects } from '$std/assert/mod.ts';
-import { isBotUserAgent, utcDay, visitorHash, withDeadline } from './qr-scans.ts';
+import { isBotUserAgent, saltCutoffDay, utcDay, visitorHash, withDeadline } from './qr-scans.ts';
 
 const SALT_A = new Uint8Array(32).fill(1);
 const SALT_B = new Uint8Array(32).fill(2);
@@ -17,6 +17,38 @@ Deno.test('utcDay formats as YYYY-MM-DD', () => {
 Deno.test('utcDay uses UTC, not the host timezone', () => {
   assertEquals(utcDay(new Date('2026-08-11T23:59:59Z')), '2026-08-11');
   assertEquals(utcDay(new Date('2026-08-12T00:00:00Z')), '2026-08-12');
+});
+
+// --- saltCutoffDay --------------------------------------------------------
+
+// Salts strictly before the cutoff are deleted, so the cutoff is yesterday:
+// today and yesterday survive, bounding any salt's age at 48 hours.
+Deno.test('the cutoff is yesterday, so today and yesterday survive', () => {
+  assertEquals(saltCutoffDay(new Date('2026-08-13T02:22:00Z')), '2026-08-12');
+});
+
+// The live case that prompted moving this off the request path: on Aug 13 an
+// Aug 11 salt must be deleted, and it was not, because nothing had visited.
+Deno.test('a two-day-old salt falls before the cutoff', () => {
+  const cutoff = saltCutoffDay(new Date('2026-08-13T02:22:00Z'));
+  assert('2026-08-11' < cutoff, `2026-08-11 should sort before ${cutoff}`);
+  assertEquals('2026-08-12' < cutoff, false); // yesterday is kept
+  assertEquals('2026-08-13' < cutoff, false); // today is kept
+});
+
+// Computed in TS from UTC rather than in SQL from CURRENT_DATE, which follows
+// the database session's timezone and would shift the window by a day.
+Deno.test('the cutoff is UTC, and late-evening UTC does not roll it early', () => {
+  assertEquals(saltCutoffDay(new Date('2026-08-13T23:59:59Z')), '2026-08-12');
+  assertEquals(saltCutoffDay(new Date('2026-08-13T00:00:00Z')), '2026-08-12');
+});
+
+Deno.test('the cutoff crosses a month boundary', () => {
+  assertEquals(saltCutoffDay(new Date('2026-08-01T09:00:00Z')), '2026-07-31');
+});
+
+Deno.test('the cutoff crosses a year boundary', () => {
+  assertEquals(saltCutoffDay(new Date('2027-01-01T09:00:00Z')), '2026-12-31');
 });
 
 // --- visitorHash ----------------------------------------------------------

--- a/scripts/prune-qr-salts.ts
+++ b/scripts/prune-qr-salts.ts
@@ -30,13 +30,23 @@ import { pruneSalts, saltCutoffDay } from '../lib/qr-scans.ts';
 
 // Match migrate.ts and the other operator scripts: load env so DATABASE_URL
 // is present when this runs from a unit file with a minimal environment.
+//
+// Unlike those scripts, the real environment WINS over the dotenv files. This
+// job deletes rows, and a stale .env in the working directory pointing at a
+// different database would make it delete the wrong ones. The unit file
+// deliberately sets no EnvironmentFile today, so nothing is inherited -- this
+// is here so that adding one later is safe rather than silently destructive.
+const inherited = new Set(Object.keys(Deno.env.toObject()));
 for (const envFile of ['.env.fresh', '.env']) {
   try {
     for (const line of (await Deno.readTextFile(envFile)).split('\n')) {
       const t = line.trim();
       if (t && !t.startsWith('#')) {
         const i = t.indexOf('=');
-        if (i > 0) Deno.env.set(t.slice(0, i).trim(), t.slice(i + 1).trim());
+        if (i > 0) {
+          const key = t.slice(0, i).trim();
+          if (!inherited.has(key)) Deno.env.set(key, t.slice(i + 1).trim());
+        }
       }
     }
   } catch { /* file optional */ }
@@ -53,7 +63,10 @@ try {
   console.error(
     `[prune-qr-salts] FAILED: ${err instanceof Error ? err.name : 'error'}`,
   );
-  Deno.exit(1);
+  // exitCode, not exit(): Deno.exit() terminates immediately and the finally
+  // below never runs, leaking the pool connection on exactly the path where
+  // the database is already unhappy.
+  Deno.exitCode = 1;
 } finally {
   await closePool();
 }

--- a/scripts/prune-qr-salts.ts
+++ b/scripts/prune-qr-salts.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env -S deno run --allow-net --allow-env --allow-read
+/**
+ * Delete QR daily salts past the retention window. Run from a timer.
+ *
+ *   deno run -A scripts/prune-qr-salts.ts
+ *
+ * Once a day's salt is gone, that day's visitor hashes cannot be recomputed
+ * by anyone -- including whoever runs this. That unrecoverability is the whole
+ * point: it is what makes "unlinkable after 48 hours" a fact about the data
+ * rather than a promise about behaviour.
+ *
+ * WHY A TIMER AND NOT JUST THE REQUEST PATH: recordScan() also prunes, but
+ * only while the object is being scanned, and a quiet noticeboard is the
+ * normal case rather than the edge case. Observed live on 2026-08-13: an
+ * Aug 11 salt was still present because nothing had visited /WillyStCo-op
+ * since Aug 11, leaving those two visitors re-linkable past the window.
+ *
+ * Both mechanisms are kept because they fail independently -- a dead timer is
+ * covered by traffic, an idle URL is covered by the timer.
+ *
+ * Exits non-zero on failure so the timer surfaces it in systemctl status
+ * rather than failing silently, which for this job would look identical to
+ * success.
+ *
+ * Spec: docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+ */
+
+import { closePool } from '../lib/db.ts';
+import { pruneSalts, saltCutoffDay } from '../lib/qr-scans.ts';
+
+// Match migrate.ts and the other operator scripts: load env so DATABASE_URL
+// is present when this runs from a unit file with a minimal environment.
+for (const envFile of ['.env.fresh', '.env']) {
+  try {
+    for (const line of (await Deno.readTextFile(envFile)).split('\n')) {
+      const t = line.trim();
+      if (t && !t.startsWith('#')) {
+        const i = t.indexOf('=');
+        if (i > 0) Deno.env.set(t.slice(0, i).trim(), t.slice(i + 1).trim());
+      }
+    }
+  } catch { /* file optional */ }
+}
+
+const now = new Date();
+try {
+  const removed = await pruneSalts(now);
+  // Counts and a date only -- nothing here identifies anyone.
+  console.log(
+    `[prune-qr-salts] cutoff=${saltCutoffDay(now)} removed=${removed}`,
+  );
+} catch (err) {
+  console.error(
+    `[prune-qr-salts] FAILED: ${err instanceof Error ? err.name : 'error'}`,
+  );
+  Deno.exit(1);
+} finally {
+  await closePool();
+}


### PR DESCRIPTION
Pruning ran only inside `recordScan`, so it stopped whenever scanning stopped. That failed in production within two days.

On 2026-08-13 the **2026-08-11 salt was still present**, because nothing had visited `/WillyStCo-op` since Aug 11 — leaving those two visitors re-linkable past the 48h window the entire unlinkability argument rests on.

The mistake was treating an idle URL as the edge case. For a QR on a wall it is the *normal* case, so the condition that disabled pruning is the condition the feature usually operates under. CodeRabbit flagged this on #94 and I documented it rather than fixing it; production then demonstrated it.

## What changed

- **`scripts/prune-qr-salts.ts`** — scheduled entry point, run from a systemd timer. This is what now guarantees the window. Exits non-zero on failure so the timer surfaces it; for this job, silent failure looks identical to success.
- **`pruneSalts()`** and one shared `SALT_PRUNE_SQL`, so the request path and the timer cannot drift apart.
- **`saltCutoffDay()`** computes the boundary in TypeScript from UTC rather than in SQL from `CURRENT_DATE`, which follows the database session's timezone and would shift the window by a day — the same trap the report query hit.

## The request-path prune is kept, deliberately

Not an oversight. The two mechanisms fail independently: a dead timer is covered by traffic, an idle URL is covered by the timer. The cost is one indexed `DELETE` against a table holding at most two rows. For a property the design rests on, that is worth paying twice.

## Verification

34 tests pass, including the boundary cases that matter: the cutoff is yesterday so today and yesterday survive; a two-day-old salt falls before it; UTC late-evening does not roll it early; month and year boundaries.

Spec updated — the section that documented this as an accepted limitation now records that it failed and how.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR scan security-data cleanup by consistently removing expired salts based on UTC time.
  * Ensured cleanup continues during periods with no QR scan activity.
  * Improved handling across month and year boundaries to prevent premature or delayed removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->