### PR TITLE
fix(romania): make PDF delivery work end to end

### DIFF
--- a/romania/deploy/README.md
+++ b/romania/deploy/README.md
@@ -15,12 +15,34 @@ Currently: `aformulationiontruth.com:2078`, Debian 13, user `liar`.
     fonts-noto-core     # Noto Serif
     fonts-noto-extra    # Noto Sans Tamil, Noto Sans Devanagari
     deno 2.x
+    python3             # send_mail.py — see below
+
+## Mail leaves through a relay
+
+This provider blocks outbound 25/465/587, so the key box cannot reach a
+submission service directly. `a4t-smtp-relay.service` opens an ssh forward to
+gimbal, and `/etc/hosts` maps `smtp.mail.me.com` to `127.0.0.1` so the client
+still _names_ the real host — SNI and certificate verification therefore
+succeed, TLS runs end to end between here and Apple, and gimbal forwards bytes
+it cannot read. The relay key is restricted at gimbal with
+`permitopen="smtp.mail.me.com:587"`, so it can open that one forward and
+nothing else.
+
+Sending is `send_mail.py`, not denomailer: denomailer 1.6.0 fails this exact
+submission (`invalid cmd`, then `Bad resource ID`) on a socket where Python
+smtplib completes STARTTLS and authenticates without complaint.
 
 ## The working directory must be tmpfs
 
-`RENDER_WORK_ROOT` defaults to `/dev/shm`. The decrypted questionnaire and the
-unprotected PDF exist there for the duration of one request, and nowhere else in
-the system. `keystore.shredIdentity` unlinks; it does not securely erase — the
+`RENDER_WORK_ROOT` defaults to **`/tmp`**, not `/dev/shm`. Deno treats
+`/dev/shm` as a special path and refuses every operation there without
+`--allow-all` (`NotCapable: Requires all access to ...`), which would mean
+un-sandboxing the service to obtain a tmpfs it already has: `/tmp` is tmpfs on
+this host, and the unit sets `PrivateTmp=true`, so the service gets a private,
+memory-backed `/tmp` that no other process can see.
+
+The decrypted questionnaire and the unprotected PDF exist there for the
+duration of one request, and nowhere else in the system. `keystore.shredIdentity` unlinks; it does not securely erase — the
 guarantee comes from the pages being memory-backed. **If the key directory or
 the work root is ever moved onto persistent storage, that guarantee is gone and
 nothing in the code will notice.**
@@ -31,7 +53,7 @@ nothing in the code will notice.**
     RENDER_BIND             default 127.0.0.1 — expose only over the mesh
     RENDER_PORT             default 8791
     KEYBOX_KEY_DIR          default /home/liar/keybox (0700)
-    RENDER_WORK_ROOT        default /dev/shm
+    RENDER_WORK_ROOT        default /tmp (tmpfs + PrivateTmp)
     RENDER_CALLBACK_URL     web tier, to stamp pdf_delivered_at
     RENDER_CALLBACK_TOKEN
     SMTP_HOST/PORT/SECURE/USER/PASS, FROM_EMAIL

--- a/romania/mailer.ts
+++ b/romania/mailer.ts
@@ -16,6 +16,8 @@
  * /proc/<pid>/cmdline.
  */
 
+import { fromFileUrl } from 'https://deno.land/std@0.216.0/path/mod.ts';
+
 export interface DeliveryMail {
   to: string;
   /** Already protected, if a password was supplied. */
@@ -49,7 +51,16 @@ function body(mail: DeliveryMail): string {
   return lines.join('\n');
 }
 
-const SENDER = new URL('./send_mail.py', import.meta.url).pathname;
+/**
+ * fromFileUrl, not URL.pathname: pathname keeps percent-encoding, so an
+ * installation path containing a space would hand python3/typst a literal
+ * "%20" and the file would not be found.
+ *
+ * The full std URL rather than a bare $std/ specifier -- this module runs
+ * standalone on the key box, which has no deno.json, so an import map is not
+ * available to resolve one.
+ */
+const SENDER = fromFileUrl(new URL('./send_mail.py', import.meta.url));
 
 export async function sendDelivery(mail: DeliveryMail): Promise<void> {
   const from = Deno.env.get('FROM_EMAIL') || Deno.env.get('SMTP_USER');

--- a/romania/mailer.ts
+++ b/romania/mailer.ts
@@ -2,33 +2,33 @@
  * Sending the finished document.
  *
  * The key box sends this, not the web tier, because only the key box can
- * decrypt the address. Handing it back to Iceland to post would mean handing
- * over the plaintext address AND the plaintext PDF -- exactly what the split
- * exists to prevent.
+ * decrypt the address. Handing it back to the web tier to post would mean
+ * handing over the plaintext address AND the plaintext PDF -- exactly what the
+ * split exists to prevent.
  *
- * Verified against denomailer 1.6.0: attachments accept
- * { encoding: 'binary', content: Uint8Array }, so the PDF goes as bytes rather
- * than being base64'd by hand.
+ * Delegates to send_mail.py. denomailer 1.6.0 fails this submission ("invalid
+ * cmd", then "Bad resource ID") on a socket where Python smtplib completes
+ * STARTTLS and authenticates without complaint; the service already shells out
+ * to typst and qpdf, so this is consistent rather than exotic.
+ *
+ * The spec file is 0600 and its path is the ONLY argument. The address, the
+ * body and the document never touch argv, which is world-readable via
+ * /proc/<pid>/cmdline.
  */
-
-import { SMTPClient } from 'https://deno.land/x/denomailer@1.6.0/mod.ts';
 
 export interface DeliveryMail {
   to: string;
-  /** The rendered document. Protected already, if a password was supplied. */
+  /** Already protected, if a password was supplied. */
   pdf: Uint8Array;
   filename: string;
-  /** Present only when the PDF is password-protected. */
   protected: boolean;
-  /** Link that re-issues a copy; omitted when re-send is unavailable. */
   resendUrl?: string;
+  /** tmpfs directory; the spec file is written and removed here. */
+  workDir: string;
 }
 
 function body(mail: DeliveryMail): string {
-  const lines = [
-    'Attached is a copy of the responses you wrote.',
-    '',
-  ];
+  const lines = ['Attached is a copy of the responses you wrote.', ''];
   if (mail.protected) {
     lines.push(
       'The document is encrypted with the password you chose. We do not have it',
@@ -38,8 +38,8 @@ function body(mail: DeliveryMail): string {
   }
   if (mail.resendUrl) {
     lines.push(
-      'If the password does not work, you can request a fresh copy — with a new',
-      'password — using the link below. It expires in seven days.',
+      'If the password does not work, you can request a fresh copy -- with a new',
+      'password -- using the link below. It expires in seven days.',
       '',
       mail.resendUrl,
       '',
@@ -49,49 +49,39 @@ function body(mail: DeliveryMail): string {
   return lines.join('\n');
 }
 
-/**
- * Mail the document. Throws on any failure; the caller decides whether to
- * retry, and must not record a delivery that did not happen.
- */
+const SENDER = new URL('./send_mail.py', import.meta.url).pathname;
+
 export async function sendDelivery(mail: DeliveryMail): Promise<void> {
-  const hostname = Deno.env.get('SMTP_HOST');
-  const port = parseInt(Deno.env.get('SMTP_PORT') || '587', 10);
-  const implicitTls = Deno.env.get('SMTP_SECURE') === 'true';
-  const username = Deno.env.get('SMTP_USER');
-  const password = Deno.env.get('SMTP_PASS');
-  const fromEmail = Deno.env.get('FROM_EMAIL') || username;
-  const fromName = Deno.env.get('SMTP_FROM_NAME') || 'a formulation of truth';
+  const from = Deno.env.get('FROM_EMAIL') || Deno.env.get('SMTP_USER');
+  if (!from) throw new Error('SMTP not configured');
 
-  if (!hostname || !username || !password || !fromEmail) {
-    throw new Error('SMTP not configured');
-  }
-
-  const client = new SMTPClient({
-    connection: { hostname, port, tls: implicitTls, auth: { username, password } },
-  });
+  const pdfPath = `${mail.workDir}/outgoing.pdf`;
+  const specPath = `${mail.workDir}/mail.json`;
 
   try {
-    await client.send({
-      from: `${fromName} <${fromEmail}>`,
-      to: mail.to,
-      subject: 'your responses',
-      content: body(mail),
-      attachments: [{
-        encoding: 'binary',
-        content: mail.pdf,
+    await Deno.writeFile(pdfPath, mail.pdf, { mode: 0o600 });
+    await Deno.writeTextFile(
+      specPath,
+      JSON.stringify({
+        to: mail.to,
+        from: `a formulation of truth <${from}>`,
+        subject: 'your responses',
+        body: body(mail),
+        pdf_path: pdfPath,
         filename: mail.filename,
-        contentType: 'application/pdf',
-      }],
-    });
+      }),
+      { mode: 0o600 },
+    );
+
+    const res = await new Deno.Command('python3', {
+      args: [SENDER, specPath],
+      stdout: 'null',
+      // Discarded: an SMTP error can echo the envelope, and the address is the
+      // one piece of PII here.
+      stderr: 'null',
+    }).output();
+    if (!res.success) throw new Error('smtp send failed');
   } finally {
-    // Always close: a leaked connection holds an authenticated session open
-    // against the provider's per-account limit. close() is typed
-    // `void | Promise<void>` in denomailer 1.6.0, so it is wrapped rather than
-    // .catch()'d -- the latter does not typecheck against the void arm.
-    try {
-      await client.close();
-    } catch {
-      // Nothing useful to do; the message is already sent or already failed.
-    }
+    for (const p of [pdfPath, specPath]) await Deno.remove(p).catch(() => {});
   }
 }

--- a/romania/render-service.ts
+++ b/romania/render-service.ts
@@ -22,8 +22,16 @@ const BIND = Deno.env.get('RENDER_BIND') || '127.0.0.1';
 const PORT = parseInt(Deno.env.get('RENDER_PORT') || '8791', 10);
 const TOKEN = Deno.env.get('RENDER_TOKEN') || '';
 const KEY_DIR = Deno.env.get('KEYBOX_KEY_DIR') || '/home/liar/keybox';
-/** tmpfs in production: plaintext must never reach persistent storage. */
-const WORK_ROOT = Deno.env.get('RENDER_WORK_ROOT') || '/dev/shm';
+/**
+ * Where the plaintext lives for the duration of one request.
+ *
+ * /tmp, NOT /dev/shm. Deno treats /dev/shm as a special path and refuses every
+ * operation there without --allow-all ("Requires all access to ..."), which
+ * would mean running this service unsandboxed to gain a tmpfs it already has:
+ * /tmp is tmpfs here, and the unit sets PrivateTmp=true, so the service gets a
+ * private, memory-backed /tmp no other process can see. Better on both counts.
+ */
+const WORK_ROOT = Deno.env.get('RENDER_WORK_ROOT') || '/tmp';
 const CALLBACK_URL = Deno.env.get('RENDER_CALLBACK_URL') || '';
 const CALLBACK_TOKEN = Deno.env.get('RENDER_CALLBACK_TOKEN') || '';
 
@@ -82,7 +90,13 @@ async function decryptWith(identity: string, ciphertext: string): Promise<string
  */
 export async function handleBundle(bundle: DeliveryBundle): Promise<void> {
   const identity = await loadIdentity(KEY_DIR, bundle.sessionId);
-  const work = await Deno.makeTempDir({ dir: WORK_ROOT, prefix: 'render-' });
+  // NOT Deno.makeTempDir({ dir }): that demands blanket filesystem access
+  // (NotCapable: "Requires all access to /dev/shm") even with --allow-read and
+  // --allow-write granted, which would force the service to run --allow-all.
+  // Creating the directory ourselves needs only write permission, so the
+  // sandbox stays narrow.
+  const work = `${WORK_ROOT}/render-${crypto.randomUUID()}`;
+  await Deno.mkdir(work, { recursive: false, mode: 0o700 });
 
   try {
     const address = await decryptWith(identity, bundle.encryptedEmail);
@@ -110,6 +124,7 @@ export async function handleBundle(bundle: DeliveryBundle): Promise<void> {
       pdf,
       filename: 'responses.pdf',
       protected: Boolean(password),
+      workDir: work,
     });
 
     // Only after the send succeeded. Recording a delivery that did not happen
@@ -207,9 +222,10 @@ if (import.meta.main) {
     try {
       await handleBundle(bundle);
       return new Response('ok', { status: 200 });
-    } catch {
-      // Category only. The thrown error can carry answer text or the address.
-      console.error('[render] delivery failed');
+    } catch (exc) {
+      // The MESSAGE is withheld -- it can carry answer text or the address --
+      // but the exception CLASS cannot, and without it a failure is undiagnosable.
+      console.error('[render] delivery failed (%s)', exc instanceof Error ? exc.name : typeof exc);
       return new Response('render failed', { status: 500 });
     }
   });

--- a/romania/render.ts
+++ b/romania/render.ts
@@ -6,6 +6,8 @@
  * system and they must never reach a disk that survives a reboot.
  */
 
+import { fromFileUrl } from 'https://deno.land/std@0.216.0/path/mod.ts';
+
 export interface RenderEntry {
   index: number;
   tamilNumeral: string;
@@ -20,7 +22,16 @@ export interface RenderDoc {
   entries: RenderEntry[];
 }
 
-const TEMPLATE = new URL('./template.typ', import.meta.url).pathname;
+/**
+ * fromFileUrl, not URL.pathname: pathname keeps percent-encoding, so an
+ * installation path containing a space would hand python3/typst a literal
+ * "%20" and the file would not be found.
+ *
+ * The full std URL rather than a bare $std/ specifier -- this module runs
+ * standalone on the key box, which has no deno.json, so an import map is not
+ * available to resolve one.
+ */
+const TEMPLATE = fromFileUrl(new URL('./template.typ', import.meta.url));
 
 /**
  * Render a document to PDF bytes.

--- a/romania/send_mail.py
+++ b/romania/send_mail.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+Send the finished document.
+
+Python rather than denomailer: denomailer 1.6.0 fails this exact submission
+("invalid cmd", then "Bad resource ID") on a socket where smtplib completes the
+STARTTLS handshake and authenticates without complaint. The render service
+already shells out to typst and qpdf, so one more subprocess is consistent, and
+email.message handles MIME and the PDF attachment without hand-rolling either.
+
+Everything sensitive arrives in a 0600 JSON file whose path is the only
+argument. Nothing -- not the address, not the password, not the document --
+goes on argv, because /proc/<pid>/cmdline is world-readable.
+"""
+import json
+import os
+import smtplib
+import ssl
+import sys
+from email.message import EmailMessage
+
+spec = json.load(open(sys.argv[1]))
+
+msg = EmailMessage()
+msg["Subject"] = spec.get("subject", "your responses")
+msg["From"] = spec["from"]
+msg["To"] = spec["to"]
+msg.set_content(spec["body"])
+
+with open(spec["pdf_path"], "rb") as fh:
+    msg.add_attachment(
+        fh.read(),
+        maintype="application",
+        subtype="pdf",
+        filename=spec.get("filename", "responses.pdf"),
+    )
+
+host = os.environ["SMTP_HOST"]
+port = int(os.environ.get("SMTP_PORT", "587"))
+secure = os.environ.get("SMTP_SECURE", "false").lower() == "true"
+ctx = ssl.create_default_context()
+
+if secure:
+    with smtplib.SMTP_SSL(host, port, timeout=60, context=ctx) as s:
+        s.login(os.environ["SMTP_USER"], os.environ["SMTP_PASS"])
+        s.send_message(msg)
+else:
+    with smtplib.SMTP(host, port, timeout=60) as s:
+        s.starttls(context=ctx)
+        s.login(os.environ["SMTP_USER"], os.environ["SMTP_PASS"])
+        s.send_message(msg)
+
+print("sent")


### PR DESCRIPTION
Makes the key box actually deliver. Everything here was found by running the pipeline against the real infrastructure, not by reading the code — four failures, each invisible until errors were made diagnosable.

## What was broken

**`/dev/shm` is unusable from Deno.** It refuses *every* operation there without `--allow-all` (`NotCapable: Requires all access to ...`), including `mkdir`. Taking that flag would have un-sandboxed the service to obtain a tmpfs it already had: `/tmp` is tmpfs on this host and the unit sets `PrivateTmp=true`, so the service gets a private, memory-backed `/tmp` no other process can see. `Deno.makeTempDir({ dir })` demands the same blanket access, so the work directory is now created with `mkdir` and a random name.

**denomailer 1.6.0 cannot send this message.** It fails `invalid cmd`, then `Bad resource ID`, on a socket where Python's `smtplib` completes STARTTLS and authenticates without complaint. Sending goes through `send_mail.py` — consistent with a service that already shells out to `typst` and `qpdf`. The address, body and document travel in a `0600` spec file whose path is the only argument; nothing sensitive touches argv, since `/proc/<pid>/cmdline` is world-readable.

**A `return` was missing** in the request handler, so it could return `undefined`. I had destroyed it by patching the catch block *by line number* after a content match failed on quote style.

**The provider blocks outbound 25/465/587**, so the key box cannot reach a submission service at all. Mail now leaves through an ssh relay to gimbal, with an `/etc/hosts` entry so the client still *names* `smtp.mail.me.com` — SNI and certificate verification succeed, TLS runs end to end to Apple, and gimbal forwards ciphertext it cannot read. The relay key is confined at gimbal by `permitopen="smtp.mail.me.com:587"`, so it can open that one forward and nothing else.

## Verification

Ran a real bundle through the deployed service: **HTTP 200**, and a `.delivered` marker written — which only happens *after* the send succeeds. A PDF of the answers arrived by mail. 29 tests pass; `deno check` clean.

## Worth reviewer attention

- The relay means gimbal is on the path between the key box and Apple. It carries only TLS ciphertext, but it is a new hop — is `permitopen` confinement sufficient?
- `send_mail.py` runs as a subprocess with SMTP credentials in its environment. Reasonable, or should it read them from the spec file too?
- The work directory is `/tmp` under `PrivateTmp=true`. That is memory-backed *on this host*; the deploy notes say so, but nothing enforces it.

@coderabbitai please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable SMTP delivery for generated PDF documents, supporting STARTTLS and SSL connections.
  - Mail messages and PDF attachments are securely packaged before transmission.
  - Temporary working files are isolated and automatically removed after processing.

- **Bug Fixes**
  - Improved handling of mail delivery failures with safer, less revealing error reporting.
  - Improved template loading for paths containing spaces and other encoded characters.

- **Documentation**
  - Updated deployment guidance for Python 3, SMTP relay configuration, SSH forwarding, and temporary storage settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->