### PR TITLE
Version the qr-salt-prune systemd units

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,35 @@
+# systemd units
+
+Host configuration, versioned here rather than living only on the server.
+
+`deploy.sh` is deliberately kept *outside* the repo (see the deploy-hardening
+spec): bash reads a script incrementally, so a deploy script inside the working
+tree would be rewritten by its own `git pull` mid-execution. That reasoning does
+not apply to unit files — systemd reads them from `/etc`, never from the working
+tree — so they belong in version control, where a rebuilt box can recover them.
+
+## qr-salt-prune
+
+Deletes QR daily salts past the retention window, hourly. This is what enforces
+unlinkability when the QR is idle; the request-path prune in `lib/qr-scans.ts`
+only runs while the object is being scanned. Both are kept because they fail
+under opposite conditions.
+
+**Best-effort, not a guarantee.** Retention is day-granular, so a salt lives
+between ~24h and ~48h depending on when in the day it was created, and the
+hourly timer adds up to ~61 minutes on top — worst case near 49 hours. Failed
+runs and host downtime extend it further; `Persistent=true` catches up after
+downtime but cannot delete retroactively. Do not quote a strict 48h figure.
+
+Install:
+
+    sudo install -m0644 deploy/systemd/qr-salt-prune.service /etc/systemd/system/
+    sudo install -m0644 deploy/systemd/qr-salt-prune.timer   /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now qr-salt-prune.timer
+
+Verify:
+
+    systemctl list-timers qr-salt-prune.timer
+    sudo systemctl start qr-salt-prune.service   # run once, now
+    journalctl -u qr-salt-prune.service -n 20    # counts and a date only

--- a/deploy/systemd/qr-salt-prune.service
+++ b/deploy/systemd/qr-salt-prune.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Prune QR daily salts past the retention window
+Documentation=https://github.com/nyagrodha/aformulationoftruth/blob/production/scripts/prune-qr-salts.ts
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ahamahamahakaha
+WorkingDirectory=/var/www/aformulationoftruth
+# EnvironmentFile, exactly as aformulationoftruth-fresh.service does it.
+#
+# This is load-bearing, not decoration: .env is 0600 and owned by wthami, so
+# ahamahamahakaha CANNOT read it. systemd reads EnvironmentFile as root before
+# dropping to User=, which is the only reason the main service works either.
+# Without this line the script finds .env unreadable, gets no DATABASE_URL,
+# and fails on every tick.
+#
+# The script's own dotenv loader then finds nothing readable and skips, and
+# its `inherited` guard makes the real environment win regardless -- which is
+# what keeps a stray .env from ever pointing this DELETE at another database.
+EnvironmentFile=/var/www/aformulationoftruth/.env
+ExecStart=/usr/local/bin/deno run --allow-net --allow-env --allow-read scripts/prune-qr-salts.ts

--- a/deploy/systemd/qr-salt-prune.timer
+++ b/deploy/systemd/qr-salt-prune.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Hourly prune of QR daily salts
+
+[Timer]
+OnCalendar=hourly
+# Catch up after downtime. Without this a box that was off across a day
+# boundary would leave an over-age salt until the next scheduled tick --
+# precisely the silent breach this timer exists to prevent.
+Persistent=true
+# Enough jitter to stay off the same instant as every other hourly job on the
+# host, small enough to keep the worst-case lateness near an hour rather than
+# an hour and five minutes. The retention boundary is a whole day, so this
+# margin is not load-bearing -- see the bound documented in README.md.
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
+++ b/docs/superpowers/specs/2026-08-11-coop-qr-scan-counting-design.md
@@ -31,7 +31,7 @@ Three things stand in the way, all verified 2026-08-11:
 |---|---|---|
 | URL | `aformulationoftruth.com/WillyStCo-op` | Human-readable; re-pointable later without reflashing the node |
 | "Discrete" | Hashed IP + user-agent, deduped per UTC day | Works when cookies are blocked; owner accepted the privacy trade-off over a cookie-based count |
-| Salt lifetime | Random per day, deleted at 48h | Makes past days permanently un-recomputable, which is what "non-linkable across days" has to mean to be true |
+| Salt lifetime | Random per day, deleted on the second UTC day after creation (age 24–48h, see below) | Makes past days permanently un-recomputable, which is what "non-linkable across days" has to mean to be true |
 | Report surface | CLI script | Adds no public HTTP surface to guard |
 | Landing | `302` to `/w/<token>` | Reuses the existing invitation page and its encounter machinery |
 
@@ -144,11 +144,31 @@ past the window this design rests on. A quiet noticeboard is the normal case
 for a QR on a wall, not the edge case, so the condition that disables pruning
 is the same condition the feature operates under most of the time.
 
-`scripts/prune-qr-salts.ts` on a systemd timer is now what guarantees the
-window. The request-path prune is kept as well, deliberately: the two fail
-independently — a dead timer is covered by traffic, an idle URL is covered by
-the timer — and the cost is one indexed `DELETE` against a table holding at
+`scripts/prune-qr-salts.ts` on a systemd timer is what enforces the window when
+the URL is idle. The request-path prune is kept as well, deliberately: the two
+fail independently — a dead timer is covered by traffic, an idle URL is covered
+by the timer — and the cost is one indexed `DELETE` against a table holding at
 most two rows.
+
+**What the deployed mechanism can actually promise.** Not a strict 48 hours,
+and it never could have been — the earlier wording overclaimed.
+
+Retention is **day-granular**, not a rolling window. A salt becomes eligible
+for deletion when the UTC date advances past `saltCutoffDay()`, i.e. at 00:00
+UTC on the second day after it was created. So a salt minted at 00:00 lives
+~48h; one minted at 23:59 lives ~24h. Its age depends only on *when in the day*
+it was created.
+
+On top of that, deletion happens at the next timer tick, not at the instant of
+eligibility: hourly with up to 60s jitter, so up to ~61 minutes late. Failed
+runs, host downtime, or a stopped timer extend it further — `Persistent=true`
+catches up after downtime but cannot retroactively delete on time.
+
+The honest statement is therefore: **a salt is normally removed within about an
+hour of becoming eligible, giving a worst case near 49 hours, and this is
+best-effort rather than a guarantee.** Anything stronger would need deletion
+driven by the database itself, which this app has no mechanism for (there is no
+`pg_cron` on the host — checked).
 
 The cutoff is computed in TypeScript from UTC (`saltCutoffDay`) rather than in
 SQL from `CURRENT_DATE`, which follows the database session's timezone and

--- a/scripts/prune-qr-salts.ts
+++ b/scripts/prune-qr-salts.ts
@@ -33,9 +33,14 @@ import { pruneSalts, saltCutoffDay } from '../lib/qr-scans.ts';
 //
 // Unlike those scripts, the real environment WINS over the dotenv files. This
 // job deletes rows, and a stale .env in the working directory pointing at a
-// different database would make it delete the wrong ones. The unit file
-// deliberately sets no EnvironmentFile today, so nothing is inherited -- this
-// is here so that adding one later is safe rather than silently destructive.
+// different database would make it delete the wrong ones.
+//
+// This is not hypothetical: qr-salt-prune.service DOES set EnvironmentFile,
+// because .env is 0600 and owned by another user, so systemd must read it as
+// root before dropping privileges -- the script cannot read it at all. So
+// DATABASE_URL always arrives inherited, and this guard is the only thing
+// keeping a stray readable .env from redirecting the DELETE. Do not remove it,
+// and do not drop EnvironmentFile from the unit.
 const inherited = new Set(Object.keys(Deno.env.toObject()));
 for (const envFile of ['.env.fresh', '.env']) {
   try {


### PR DESCRIPTION
Follow-up to #95. The units commit didn't make it into that squash — #95 was merged after the review fixes but before `4431f3a`, so production has `scripts/prune-qr-salts.ts` but no unit files. This adds them, with a correction found while installing on the host.

## The correction

The unit originally carried:

```
# No EnvironmentFile: .env holds values systemd's strict parser would reject.
```

That was asserted and never verified, and it's false — `aformulationoftruth-fresh.service` has been parsing this exact file for days.

The real constraint is the opposite one: `.env` is `0600` owned by `wthami`, so the service user `ahamahamahakaha` **cannot read it**. The main service works only because **systemd reads `EnvironmentFile=` as root before dropping to `User=`** — it never reads that file as its own user. My script did, so it failed on every tick with no `DATABASE_URL`.

This also makes the `inherited` guard from #95 load-bearing rather than hypothetical: `DATABASE_URL` now genuinely arrives in the process environment, which is exactly the case where the dotenv loader must not override it.

## Verified on the host

Installed, `daemon-reload`, enabled:

```
[prune-qr-salts] cutoff=2026-08-13 removed=0     # only today's salt present
[prune-qr-salts] cutoff=2026-08-13 removed=1     # after inserting a stale 2026-08-01 salt
```

A deliberately stale salt was removed and today's was kept. Timer is `enabled`/`active` and scheduled hourly with `Persistent=true`.

## Unrelated but worth noting

The server's timezone has changed from `Etc/UTC` to `America/Chicago` since Aug 13. This has no effect here because the cutoff is computed in TypeScript from UTC (`saltCutoffDay`) rather than in SQL from `CURRENT_DATE` — had it used `CURRENT_DATE`, the window would now lag by a day for five hours out of every twenty-four.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated QR salt cleanup that runs hourly.
  - Cleanup is scheduled to resume after downtime and uses a randomized delay to distribute processing.
  - Added safeguards to remove expired salts while preserving active ones.

- **Documentation**
  - Added deployment and verification guidance for enabling the cleanup service.
  - Clarified QR salt retention rules, including day-based expiration and best-effort deletion timing.
  - Documented independent cleanup safeguards for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->