### PR TITLE
feat(consent): two styled buttons instead of radios

### DIFF
--- a/public/css/consent.css
+++ b/public/css/consent.css
@@ -1,31 +1,47 @@
 /* Consent to receive a PDF copy of one's responses.
  *
- * The password panel appears only when "Yes, please" is selected, and it does
- * so with a sibling combinator rather than script. That is deliberate: the
- * gate works without JavaScript, so the page that decides what happens to a
- * respondent's answers must too. If this were JS-driven, a visitor with script
- * disabled would see no password field at all and would silently receive an
- * unprotected PDF while believing otherwise.
+ * The choice is made by pressing one of two submit buttons that share the
+ * field name `consent`. A browser sends only the pressed button's name/value,
+ * so the answer reaches the server with no script involved. That matters: the
+ * gate works without JavaScript, so the page deciding what happens to a
+ * respondent's answers must too.
  *
- * The selector REQUIRES .consent-yes and .pw-panel to be siblings. Nesting the
- * radio inside its label breaks it with no error and no visual clue.
+ * The password field is always visible. It was previously revealed by
+ * `.consent-yes:checked ~ .pw-panel`, which depended on a radio that no longer
+ * exists; a CSS-only reveal cannot be rebuilt without reintroducing a hidden
+ * control, and a JS reveal would leave a script-less visitor with no password
+ * field at all, silently receiving an unprotected PDF while believing
+ * otherwise. Always-visible-and-optional is the version that cannot lie.
  */
-.pw-panel {
-  display: none;
-}
-
-.consent-yes:checked ~ .pw-panel {
-  display: block;
+.consent {
+  margin: 0 auto 2rem;
+  max-width: 42ch;
+  text-align: left;
 }
 
 .consent-question {
   margin-bottom: 0.75rem;
 }
 
-.consent-choice {
-  display: inline-block;
-  margin-right: 1rem;
-  cursor: pointer;
+.pw-panel {
+  margin-bottom: 1.25rem;
+}
+
+.pw-panel input[type='password'] {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  background: var(--obsidian, #0a0a0a);
+  border: 1px solid var(--ghost, #2a2a2a);
+  border-radius: 4px;
+  color: var(--bone, #e8e8e8);
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+.pw-panel input[type='password']:focus {
+  outline: none;
+  border-color: var(--neon-pink, #ff69b4);
+  box-shadow: 0 0 8px var(--pink-glow, rgba(255, 105, 180, 0.4));
 }
 
 .pw-note {
@@ -33,4 +49,81 @@
   opacity: 0.8;
   max-width: 42ch;
   margin-top: 0.4rem;
+}
+
+/* The two submit buttons. */
+.consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.consent-btn {
+  padding: 0.7rem 1.6rem;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.consent-btn:hover {
+  transform: translateY(-1px);
+}
+
+.consent-btn:active {
+  transform: translateY(0);
+}
+
+/* "Yes, please" -- hot pink into orange, warm and inviting. */
+.consent-btn-yes {
+  background: linear-gradient(
+    135deg,
+    var(--neon-pink, #ff69b4) 0%,
+    var(--neon-orange, #ff8c42) 100%
+  );
+  border: 2px solid var(--neon-orange, #ff8c42);
+  color: var(--void, #000000);
+  box-shadow: 0 0 12px var(--pink-glow, rgba(255, 105, 180, 0.4));
+}
+
+.consent-btn-yes:hover {
+  box-shadow:
+    0 0 18px var(--pink-glow, rgba(255, 105, 180, 0.4)),
+    0 0 32px var(--orange-glow, rgba(255, 140, 66, 0.4));
+  filter: brightness(1.08);
+}
+
+/* "No, thanks" -- black with neon blue, cool and quiet by comparison. */
+.consent-btn-no {
+  background: var(--void, #000000);
+  border: 2px solid #00e5ff;
+  color: #00e5ff;
+  text-shadow: 0 0 8px rgba(0, 229, 255, 0.6);
+  box-shadow:
+    0 0 10px rgba(0, 229, 255, 0.35),
+    inset 0 0 10px rgba(0, 229, 255, 0.12);
+}
+
+.consent-btn-no:hover {
+  box-shadow:
+    0 0 18px rgba(0, 229, 255, 0.55),
+    inset 0 0 14px rgba(0, 229, 255, 0.2);
+}
+
+.consent-btn:focus-visible {
+  outline: 2px solid var(--light, #ffffff);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .consent-btn {
+    transition: none;
+  }
+
+  .consent-btn:hover {
+    transform: none;
+  }
 }

--- a/routes/completion.tsx
+++ b/routes/completion.tsx
@@ -32,28 +32,31 @@ export const handler: Handlers<CompletionData> = {
 /**
  * Consent to receive a PDF copy.
  *
- * No JavaScript. The password panel is revealed by a CSS sibling selector on
- * the checked radio (public/css/consent.css). The gate is deliberately usable
- * without script -- gate-submit parses urlencoded bodies for exactly that
- * reason -- and this page must not be the exception.
+ * No JavaScript, and no radios. The answer is carried by WHICH submit button
+ * the respondent presses: a form submitted by a button sends only that
+ * button's name/value pair, so `consent=yes` or `consent=no` arrives from the
+ * browser itself with nothing scripted in between. The gate is deliberately
+ * usable without script -- gate-submit parses urlencoded bodies for exactly
+ * that reason -- and this page must not be the exception.
+ *
+ * `value='yes'` must stay exactly that, lowercase: consentFrom() in
+ * routes/api/responses/deliver.ts accepts only the literal string 'yes' and
+ * reads everything else as a refusal.
+ *
+ * The password field is now ALWAYS visible. It used to be hidden behind
+ * `.consent-yes:checked ~ .pw-panel`, which needed a radio to check; with the
+ * radios gone that selector has nothing to hang on, and the only ways to
+ * restore a reveal would be script (breaking the no-JS guarantee) or a hidden
+ * checkbox hack (a control the respondent cannot see but can still tab into).
+ * An always-visible optional field is the honest version: whoever wants a
+ * password types one before pressing "Yes, please", and whoever does not
+ * simply leaves it empty.
  */
 export function ConsentForm({ resumeToken }: { resumeToken: string }) {
   return (
     <form method='post' action='/api/responses/deliver' class='consent'>
       <input type='hidden' name='resume_token' value={resumeToken} />
       <p class='consent-question'>Would you like a copy of your responses e-mailed to you?</p>
-
-      {
-        /*
-        The radio must NOT be nested inside its label. `.consent-yes:checked ~
-        .pw-panel` is a sibling combinator and siblings must share a parent;
-        nested, the input's only sibling is the label text, the panel can never
-        be revealed, and on the no-JS path the password field silently does not
-        exist. Input hoisted to the form, label bound by for/id.
-      */
-      }
-      <input type='radio' name='consent' value='yes' id='consent-yes' class='consent-yes' required />
-      <label class='consent-choice' for='consent-yes'>Yes, please</label>
 
       <div class='pw-panel'>
         <input
@@ -69,10 +72,10 @@ export function ConsentForm({ resumeToken }: { resumeToken: string }) {
         </p>
       </div>
 
-      <input type='radio' name='consent' value='no' id='consent-no' required />
-      <label class='consent-choice' for='consent-no'>No</label>
-
-      <button type='submit' class='cta cta-primary'>Send me a .pdf email</button>
+      <div class='consent-actions'>
+        <button type='submit' name='consent' value='yes' class='consent-btn consent-btn-yes'>Yes, please</button>
+        <button type='submit' name='consent' value='no' class='consent-btn consent-btn-no'>No, thanks</button>
+      </div>
     </form>
   );
 }

--- a/tests/completion_consent_test.tsx
+++ b/tests/completion_consent_test.tsx
@@ -8,7 +8,7 @@
  * Run with: deno task test
  */
 
-import { assert, assertStringIncludes } from 'https://deno.land/std@0.208.0/assert/mod.ts';
+import { assert, assertEquals, assertStringIncludes } from 'https://deno.land/std@0.208.0/assert/mod.ts';
 import { render } from 'preact-render-to-string';
 import { ConsentForm } from '../routes/completion.tsx';
 
@@ -20,8 +20,8 @@ Deno.test('ConsentForm - carries the exact approved copy', () => {
       'you may request another copy of the pdf be sent to you.',
   );
   assertStringIncludes(html, 'Would you like a copy of your responses e-mailed to you?');
-  assertStringIncludes(html, 'Yes, please');
-  assertStringIncludes(html, 'Send me a .pdf email');
+  assertStringIncludes(html, '>Yes, please<');
+  assertStringIncludes(html, '>No, thanks<');
   assertStringIncludes(html, 'placeholder="optional password"');
 });
 
@@ -30,46 +30,73 @@ Deno.test('ConsentForm - works without JavaScript', () => {
   assertStringIncludes(html, 'method="post"');
   assertStringIncludes(html, 'action="/api/responses/deliver"');
   assert(!html.includes('onclick'), 'no inline JS handlers');
+  assert(!/\son[a-z]+=/i.test(html), 'no inline event-handler attributes of any kind');
 });
 
-// Scoped to the password input: the radios legitimately carry `required`, so
-// asserting across the whole form would be a guaranteed failure.
 Deno.test('ConsentForm - password field is optional and not autofilled', () => {
   const html = render(<ConsentForm resumeToken='tok-1' />);
   const pw = html.slice(html.indexOf('type="password"'));
   const pwTag = pw.slice(0, pw.indexOf('>'));
   assert(!pwTag.includes('required'), 'password must be optional');
   assertStringIncludes(html, 'autocomplete="new-password"');
+  assertStringIncludes(html, 'maxlength="256"');
 });
 
-// The CSS reveal is `.consent-yes:checked ~ .pw-panel`, a sibling combinator --
-// siblings must share a parent. If the radio is ever nested back inside its
-// label, its only sibling becomes the label text and the panel can never be
-// revealed: on the no-JS path the password field would silently not exist.
-// This asserts the structural property the stylesheet depends on.
-Deno.test('ConsentForm - radio is a sibling of the password panel, not nested in a label', () => {
+// The answer rides on WHICH submit button is pressed. A browser sends only the
+// pressed button's name/value, so two submit buttons sharing name="consent"
+// carry the choice with no script anywhere. Radios would need a CSS or JS
+// reveal for the password panel; buttons need neither.
+Deno.test('ConsentForm - two submit buttons named consent carry the answer', () => {
   const html = render(<ConsentForm resumeToken='tok-1' />);
 
-  const radio = html.indexOf('id="consent-yes"');
-  const panel = html.indexOf('pw-panel');
-  assert(radio !== -1 && panel !== -1, 'both the radio and the panel must render');
-  assert(radio < panel, 'the radio must precede the panel for ~ to match');
+  const buttons = html.match(/<button[^>]*>/g) ?? [];
+  assertEquals(buttons.length, 2, 'exactly two buttons');
 
-  // No <label ...> may open between the radio and the panel and remain unclosed.
-  const between = html.slice(radio, panel);
-  const opened = (between.match(/<label/g) || []).length;
-  const closed = (between.match(/<\/label>/g) || []).length;
-  assert(opened === closed, 'the radio must not sit inside an unclosed label');
+  for (const button of buttons) {
+    assertStringIncludes(button, 'type="submit"');
+    assertStringIncludes(button, 'name="consent"');
+  }
+
+  // consentFrom() in routes/api/responses/deliver.ts accepts ONLY the literal
+  // lowercase 'yes'; anything else -- including 'Yes' -- is read as a refusal.
+  const yes = buttons.find((b) => b.includes('value="yes"'));
+  const no = buttons.find((b) => b.includes('value="no"'));
+  assert(yes, 'a button must submit consent=yes, exactly lowercase');
+  assert(no, 'a button must submit consent=no');
+
+  assertStringIncludes(html, `${yes}Yes, please</button>`);
+  assertStringIncludes(html, `${no}No, thanks</button>`);
+});
+
+// The radios are gone for good. `.consent-yes:checked ~ .pw-panel` cannot work
+// without one, so a radio reappearing here means the password panel reveal was
+// half-restored -- and the panel would be hidden with nothing able to show it.
+Deno.test('ConsentForm - no radio inputs remain', () => {
+  const html = render(<ConsentForm resumeToken='tok-1' />);
+  assert(!html.includes('type="radio"'), 'no radio inputs');
+  assert(!html.includes('consent-yes'), 'no leftover radio hook for the old CSS reveal');
+});
+
+// With no radio to check, nothing can reveal a hidden panel without script.
+// The field must therefore render unconditionally, and it must precede the
+// buttons so a password is typed before the choice is submitted.
+Deno.test('ConsentForm - password field is always visible, above the buttons', () => {
+  const html = render(<ConsentForm resumeToken='tok-1' />);
+
+  const pw = html.indexOf('type="password"');
+  const firstButton = html.indexOf('<button');
+  assert(pw !== -1, 'the password field must render unconditionally');
+  assert(firstButton !== -1 && pw < firstButton, 'the password field must come before the buttons');
+
+  // Nothing in the markup may hide it: no hidden attribute, no inline display:none.
+  const pwTag = html.slice(pw, html.indexOf('>', pw));
+  assert(!pwTag.includes('hidden'), 'the password field must not be hidden');
+  assert(!/display\s*:\s*none/.test(html), 'nothing in the form may be hidden inline');
 });
 
 Deno.test('ConsentForm - carries the resume token so delivery knows the session', () => {
   const html = render(<ConsentForm resumeToken='tok-abc' />);
+  assertStringIncludes(html, 'type="hidden"');
   assertStringIncludes(html, 'name="resume_token"');
   assertStringIncludes(html, 'value="tok-abc"');
-});
-
-Deno.test('ConsentForm - offers a No option', () => {
-  const html = render(<ConsentForm resumeToken='tok-1' />);
-  assertStringIncludes(html, 'value="no"');
-  assertStringIncludes(html, '>No<');
 });


### PR DESCRIPTION
Replaces the radio-button consent UI with two submit buttons: **Yes, please** (hot pink → orange gradient) and **No, thanks** (black with neon blue).

Still works without JavaScript. Two submit buttons share the field name, so the browser sends only the pressed button's `name=value` — `consent=yes` or `consent=no` — with no script involved.

The password field is now always visible. The old reveal was `.consent-yes:checked ~ .pw-panel`, a CSS sibling selector on the radio; with the radios gone that selector cannot work, and reintroducing JS to toggle it would break the no-JS path.

**One thing for your attention:** the standalone `Send me a .pdf email` button is gone. With two *named* submit buttons, a third unnamed one would post no `consent` field at all, which `consentFrom` reads as "no" — clicking it would silently decline. That was approved copy and it now appears nowhere.

7 tests pass; `deno check` clean.

@coderabbitai please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the consent form with clear Yes and No submit buttons.
  * Kept the optional password field visible at all times.
  * Added responsive button states, including hover, focus, active, and reduced-motion behavior.

* **Bug Fixes**
  * Improved no-JavaScript consent submission handling.
  * Added validation for password length and consent values.
  * Preserved hidden resume-token functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->