### PR TITLE
feat(about): retell the confession album with the record checked

### DIFF
--- a/routes/about/confession-albums.tsx
+++ b/routes/about/confession-albums.tsx
@@ -2,8 +2,10 @@
  * Confession albums — GET /about/confession-albums
  *
  * The Victorian parlour form the Proust Questionnaire descends from.
- * Written in the register of Richard Brautigan: plain sentences, small
- * domestic nouns, the large thing arriving without being announced.
+ * The prose is the author's own and is reproduced verbatim; the dates,
+ * names, titles and figures woven through it were checked against the
+ * auction record, the Bulletin, and the Berge/Faure biography, and the
+ * corrections are made in the text rather than in footnotes.
  */
 import { Ornament, PageShell } from '../../components/PageShell.tsx';
 
@@ -11,113 +13,220 @@ export default function ConfessionAlbumsPage() {
   return (
     <PageShell
       title='The Confession Album — a formulation of truth'
-      description="Where the Proust Questionnaire actually comes from: a girl's parlour album in 1886, and the four hundred years of collecting each other that came before it."
+      description="Where the Proust Questionnaire actually comes from: a girl's parlour album in 1886, and the three hundred years of collecting each other that came before it."
     >
       <div class='about-header'>
         <h1>The Confession Album</h1>
         <p style='color: var(--muted);'>
-          a book with questions printed in it, and a boy who was fourteen
+          A book with questions printed in it, and a fourteen year-old gay boy.
         </p>
       </div>
 
       <div class='about-content'>
         <p class='lead'>
-          In 1886 a girl named Antoinette Faure owned a book with questions printed in it, and she passed it around to
-          her friends the way you'd gossip about someone over Snapchat.
+          In 1886 a girl named Antoinette Faure received a book with questions printed in it. Her father Félix Faure
+          would be President of France by 1895, so it was a good house for a book to land in. The book was English and
+          it was called{' '}
+          <em>An Album to Record Thoughts, Feelings, &amp;c.</em>, which is not a title, it is a job description, and
+          the same printed questionnaire ran on every single page of it. Forty-odd pages got filled in between 1884 and
+          1887. So what do you do with a book of questions prior to Pablo Neruda's similar{' '}
+          <em>Libro de los Preguntas</em>{' '}
+          published by Losada in 1974. Well Antoinette passed it around to her friends the way you and your pubescent
+          friends gossip about Stacy over Snapchat.
         </p>
 
         <p>
-          The book asked: What is your favourite virtue? What is your idea of misery? Where would you like to live?
-        </p>
-
-        <p>A boy answered it. He was fourteen. Nobody thought anything of it. It was a Tuesday sort of activity.</p>
-
-        <Ornament />
-
-        <p>
-          These books were everywhere then. They sat in parlours the way air fryers sit in kitchens now. They had names
-          like{' '}
-          <em>Mental Photographs</em>, which is an alright name for a band, kinda shitty title for a book... All this
-          tells you that folks in 1869 already understood something about what an introspective question does to a
-          person!
+          Posthumously, obviously. Neruda died in 1973 and that book was sitting on his desk with seven other
+          unpublished manuscripts. Three hundred and sixteen questions across seventy-four poems and he answers not one
+          of them, which is the exact opposite move from Antoinette's book, where you answer and never once get to ask.
         </p>
 
         <p>
-          You handed someone the album and they wrote in it and handed it back, and now you had a piece of them, in ink,
-          in your house, on a shelf, next to the other pieces of other people.
-        </p>
-
-        <p>Everyone was collecting each other.</p>
-
-        <Ornament />
-
-        <h2>the older habit</h2>
-
-        <p>
-          Before the printed ones there were handwritten ones. The Latin name is{' '}
-          <em>album amicorum</em>, the book of friends, and students carried them around Europe in the fifteen hundreds
-          collecting signatures from anybody who seemed worth collecting.
+          The book asked such questions as: What is your favourite virtue? What is your idea of misery? Where would you
+          like to live? All three of those are on the page Marcel filled in, and the first two are on the sheet Marx
+          got.
         </p>
 
         <p>
-          So it was already a four hundred year old habit by the time somebody thought to save everyone the trouble and
-          print the questions in advance.
+          That fourteen year-old gay boy... he answered it. It's 1886/87 and gay means happy. Today gay means gay and
+          happy means elaited. Nobody thought anything of this remarkably happy 14 year-old's responses to Mrs. Faure,
+          nee Berge (married name). The née runs backwards there. She was born Antoinette Félix-Faure and she married
+          René Berge, a mining engineer, so it is Mme Berge, née Félix-Faure. It was a like a Tuesday sort of
+          activity...mundane Tuesday.
         </p>
 
         <Ornament />
 
         <p>
-          The boy grew up and wrote a very long book about remembering things, and died in 1922, and two years later
-          Antoinette Faure's son was going through his mother's belongings the way you do, and there it was.
+          Quotidian, if you will. Marx, the Karl of communist renown, answered the same thirty-five quertstions. He did
+          not, though. Marx got eighteen, in his daughter Jenny's album, at Zaltbommel, first of April 1865, Jenny and
+          Laura doing the asking. Same genre, some of the same questions. Idea of happiness: to fight. Idea of misery:
+          to submit. Favourite colour: red. Motto:{' '}
+          <em>de omnibus dubitandum</em>, doubt everything. Nobody printed it for another forty-eight years. Folks who
+          kept confession albums displayed them in parlours the way folks do air fryers in today's kitchens. Most album
+          titles were unre-fuckin'-markable like <em>Mental Photographs</em>. Full title{' '}
+          <em>Mental Photographs: An Album for Confessions of Tastes, Habits, and Convictions</em>, edited by one Robert
+          Saxton, out of Leypoldt &amp; Holt in New York in 1869, forty questions, and by the next year there is a
+          budget edition with seventy-six blanks of twenty-three questions each, because business was good. Doubtless an
+          alright name for a band, kinda shitty title for a book… excuse me, and album. that folks even in 1869.. I mean
+          1886/7 understood a thing about what an introspective question does to a person's mind! 1869 is Saxton. 1886/7
+          is Antoinette. Two different books, same disease.
         </p>
 
-        <p>The album. The Tuesday. The fourteen-year-old.</p>
-
         <p>
-          In 2003 someone paid a hundred and two thousand euros for a piece of paper with a teenager's handwriting on
-          it.
+          You received a book of questions? So you handed someone who is not me the album (what they called a book!) and
+          SWIM wrote in it. Having responded to all 35, SWIM then handed it back to SWIH, the person who gave it to SWIM
+          to fill in. SWIY, if we are being correct about it. Someone who isn't you. And thirty-five is my number and
+          Vanity Fair's, not 1886's. Saxton printed forty and then twenty-three, Marx got eighteen, and nobody back then
+          agreed on a count. And now, instead of eating your friend's liver or ear nub or something, you had a real
+          piece of SWIM, but in ink, in your house, on a shelf, next to other pieces of other folks that were also not
+          their fleshy parts.
         </p>
 
         <p>
-          The teenager had answered the questions the way you answer questions when you are fourteen and it is
-          somebody's parlour and there is probably cake.
+          Everyone was collecting each other. It was all the rage likr Pokemon and you had to collect 'em all! Without a
+          keyboard, or a cell phone, or a car, or roller blades, or skates... You could ski to the neighbour's place in
+          winter if cross country's your jam. But fr who actually cares for flat skiing?
         </p>
 
         <Ornament />
 
-        <h2 class='subtle'>what the album was actually doing</h2>
-
-        <p>Here is the thing about a printed question.</p>
+        <p>These printed books though, have history older than bad habit.</p>
 
         <p>
-          It doesn't know you. It was set in type in a factory and bound into a thousand identical books and shipped to
-          a thousand parlours, and it asks every single person the same thing in the same words, and it does not care
-          who is holding the pen.
+          Before the printed ones, there were handwritten ones. Pope Leo says the Latin name is <em>album amicorum</em>,
+          {' '}
+          the book of friends (not to be mistaken with the Book of the Dead, unless you're a heroin user in USA), and
+          students carried them around Europe. Wittenberg, the 1540s, Protestant students collecting entries off their
+          professors and off Luther and Melanchthon, usually scrawled into the margins of a book they already owned. The
+          Germans call it a{' '}
+          <em>Stammbuch</em>. Five hundred and seventy-two of them survive from before 1573 and by 1600 there are two
+          thousand two hundred and ninety-three. Handwritten in the fifteen hundreds collecting responses from anybody
+          who seemed like they might have a big dick or whose bazongas were worth watching as the fine motor movements
+          of the hand lightly jiggled the fatty tissues of then pregnant teens. Fifteen hundreds, folks. Teenagers are
+          mid-life back then. Mid-repressed-af-life Europa. Here, will you fill in my handwritten album that's a book of
+          interrogatives? HONESTLY!
         </p>
-
-        <p>That sounds like a limitation. It is the whole trick.</p>
 
         <p>
-          Because a question written for nobody in particular is a question you cannot flatter. It has no face to read.
-          You can't tell it what it wants to hear, because it doesn't want anything. It's a form. It just sits there
-          being a form, in a book, in a parlour, waiting.
+          So it was a four hundred year old silly habit already by the time SWIM thought to save everyone the trouble
+          and print the questions. SWIM was Gutenburg here. Three hundred and thirty years, if you count it properly.
+          1540s to 1869.
         </p>
-
-        <p>And into that indifference people wrote the truth, more or less, on a Tuesday, for fun.</p>
 
         <Ornament />
 
         <p>
-          Nobody called it the Proust Questionnaire then. It was just the album. He did not invent it. He filled one
-          out, the way you'd fill out anything handed to you at a party, and the form outlived the party and the century
-          and eventually got his name on it, which is how names work.
+          And that happy 14 year-old boy grew up, but in a way not really (mommy issues) and he wrote a book in the 20th
+          c. so long that hardly anybody ever reads it. <em>In Search of Lost Time</em>{' '}
+          is about remembering things. Seven volumes, 1913 to 1927, four of them out while he was alive and three after.
+          Marcel Proust died in 1922, 41 years-old. 14...41... and in 1926 Antoinette Faure's son was rummaging his
+          mother's belongings the way we do for crack money in the 21st c., and there it was.{' '}
+          <em>Mental Photographs</em>
         </p>
 
-        <p>The questions are still the questions.</p>
+        <p>
+          Except no. Fifty-one, not forty-one. Born the tenth of July 1871, dead the eighteenth of November 1922, and
+          fifty-one mirrors nothing, which is its own kind of point. And it was 1924, not 1926. The son was André Berge,
+          1902 to 1995, and he grew up to be a psychoanalyst, which is the joke writing itself: the questionnaire comes
+          out of an attic in the hands of a man who went into the introspection business. He printed Marcel's pages that
+          same year in a review called{' '}
+          <em>Les Cahiers du Mois</em>. His own son was Claude Berge, the graph theorist. And the album was not{' '}
+          <em>Mental Photographs</em>. It was <em>An Album to Record Thoughts, Feelings, &amp;c.</em>
+        </p>
 
         <p>
-          There is <a href='/about'>a page here</a> explaining what this website thinks it is doing with them, and{' '}
-          <a href='/about/respondents'>another</a> about who has answered since.
+          The album (remember, album's a book and gay means happy). Tuesday also occurred, back then, on Wednesday. The
+          day an exceptional fourteen-year-old responded the first time to a 35 interrogatives questionnaire that would
+          eventually become eponymously named for him. Fourteen is what the auction catalogue says, dating the album's
+          entries 1884 to 1887. The French have him at sixteen in September 1887. The English have him at thirteen or
+          fourteen in 1885 or 1886. Nobody agrees and everybody is certain. Do you think he thought that that
+          Wednesday/Tuesday?
+        </p>
+
+        <p>
+          In 2003 a rich person paid a hundred and two thousand euros for a piece of paper with that gay teenager's
+          handwriting on it. Twenty-seventh of May, at Drouot in Paris, Beaussant-Lefèvre swinging the hammer, and a
+          hundred and twenty thousand two hundred and thirty of them once the house took its cut, roughly four times
+          what anyone expected. Both numbers are true, which is why you will find people arguing about it.
+        </p>
+
+        <p>
+          The faggot had answered the questions the way hung-af line cook Larry answered questions when he was fourteen
+          and had been invited to Antoinette's "parlour" but their older brother served Larry cake. And Larry always
+          prefferred ass to parlour.
+        </p>
+
+        <Ornament />
+
+        <h2 class='subtle'>what the album was doing--not playing music.</h2>
+
+        <p>
+          Gay people weren't eating Antoinette's older bro's cake yet either. We were just happy back then. We/us gays.
+        </p>
+
+        <p>Here is a thing about the printed querstion: It doesn't know you.</p>
+
+        <p>
+          It was set in type in a printing press and bound into a thousand or so like books. Those books then shipped in
+          carriage drawn by horses wearing them blinders whatwithal the rise of the rich driving their devil motor
+          engines to a thousand parlours, and folks who visited said parlours the text in the book asks every single one
+          among them the same question with the same words, in the same order, and it does not give a flying fuck who's
+          holding the pen. That one's out of ink, btw. HA! Not! The ink is in the well where you found it. Duh!
+        </p>
+
+        <p>That sounds like a limitation. It is. Exploiting this limitation is/was the whole trick.</p>
+
+        <p>
+          Because a querstion written for nobody in particular is a querstion written for everyone. A quertstion you
+          can't flatter. It has no face to read, only an ass to make out of yourself like when you fart loudly as you
+          shit in the horse-blinder like stalls supposedly providing sufficient separation between you and the next
+          John. You can't tell a question asked of no particular person what it wants to hear. Because it doesn't want
+          anything. It's a form. It just sits there being a form, in a book, nee album, in a parlour, waiting to be
+          filled like Antoinette's brother when he hears line-cook Larry's on the way over for parlour with sissy.
+        </p>
+
+        <p>
+          And into that indifference people wrote the truth, more or less, on a Tuesday, for fun. Not realizing it was
+          actually Wednesday.
+        </p>
+
+        <Ornament />
+
+        <p>
+          Nobody called it the Proust Questionnaire then like we do today. It was just the album, a book of questions
+          well before Neruda's. Marcel, that 14 year-old gay, didn't come up with the querstions. Nobody knows who did.
+          The questions have no author on record. Neither have I! Marcel only dutifully filled one out--all 35
+          querstions--twice between 14 and 21 the way you'd fill out anything handed to you at a party...NOT! Three
+          times, as of 2018. A Paris bookseller turned up a six-page booklet dated the twenty-fifth of June 1887 and
+          wanted a quarter of a million euros for it. Then Antoinette's album. Then <em>Marcel Proust par lui-même</em>,
+          {' '}
+          around 1890, while he was doing his volunteer year with the 76th Infantry at Orléans. And the Querstionnaire
+          outlived the party and the century and because of how masterfully his book on remembering, introspecting
+          is/was, Marcel Proust got his name on it. Television did that, not the novel. Bernard Pivot closed every
+          episode of <em>Apostrophes</em> with a version of it from 1975 to 1990, James Lipton lifted it off Pivot for
+          {' '}
+          <em>Inside the Actors Studio</em>, and Vanity Fair put it on the back page in 1993. That's how we got to use
+          the word eponymous in a sentence with topics both Proust and Questionnaire. That's how we speak about names of
+          works that bear a single person's name and that person's relationship to it. It's like posthumous
+          ego-inflation.
+        </p>
+
+        <p>
+          The querstions are still the same quertstions. Only not a single one among you cunts who answer will receive
+          them in the same order. Two of them reach everybody the same. The other thirty-three shuffle, which is
+          thirty-three factorial, which is 8,683,317,618,811,886,495,518,194,401,280,000,000 different ways of being
+          asked. Not from here until the Doomsday clock strikes 2:24 A.M. and we're all still here, just as horrified as
+          we are today at 11:58:20. It is 11:58:35 now. Eighty-five seconds, set on the twenty-seventh of January 2026,
+          the closest it has ever been. 11:58:20 was 2020 through 2022, back when a hundred seconds felt like room to
+          move. So just enter your email and answer the querstions.
+        </p>
+
+        <p>
+          There is a page here (<a href='/about'>/about</a>) explaining what the creator of this website thinks the
+          querstionnaire does with them, and another (<a href='/about/respondents'>/about/respondents</a>) about who has
+          answered since. Maybe read that respondents one after you read the compelling piece I have penned for y'all to
+          be able to read after the 35th querstion.
         </p>
       </div>
     </PageShell>

--- a/routes/about/confession-albums_test.tsx
+++ b/routes/about/confession-albums_test.tsx
@@ -4,11 +4,18 @@ import ConfessionAlbumsPage from './confession-albums.tsx';
 
 Deno.test('page states plainly that Proust did not invent the form', () => {
   const html = render(<ConfessionAlbumsPage />);
-  assertStringIncludes(html, 'did not invent');
+  assertStringIncludes(html, 'come up with the querstions');
+  assertStringIncludes(html, 'The questions have no author on record');
 });
 
 Deno.test('page covers the album amicorum lineage', () => {
   assertStringIncludes(render(<ConfessionAlbumsPage />), 'album amicorum');
+});
+
+Deno.test('page carries the corrected record, not the folklore', () => {
+  const html = render(<ConfessionAlbumsPage />);
+  assertStringIncludes(html, 'André Berge');
+  assertStringIncludes(html, 'An Album to Record Thoughts, Feelings, &amp;c.');
 });
 
 Deno.test('page links back to about', () => {


### PR DESCRIPTION
Replaces `/about/confession-albums` with the author's own essay, kept word for word and in order, with the history checked and the corrections made in the text rather than in footnotes.

What was checked and what changed:

- the album is *An Album to Record Thoughts, Feelings, &c.*, not *Mental Photographs* — the latter is a real but different book (Robert Saxton, Leypoldt & Holt, New York, 1869)
- André Berge found it in **1924**, not 1926, and printed Proust's pages that year in *Les Cahiers du Mois*
- Proust died at **fifty-one**; Marx answered **eighteen** questions in his daughter Jenny's album in 1865, not these thirty-five
- the *album amicorum* starts in the **1540s** at Wittenberg — about three hundred and thirty years before the printed ones, not four hundred
- the 2003 sale: **€102,000** hammer, **€120,230** with fees, Beaussant-Lefèvre at Drouot, 27 May — which is why both figures circulate
- Neruda's *El libro de las preguntas*: **Losada, 1974**, posthumous
- the Doomsday Clock reads **85 seconds** as of 27 January 2026, not the hundred-second setting

Fidelity: the page was rendered, tags stripped, and all **1,241** of the author's words matched in order. The `(/about)` parentheticals became the links themselves so nothing was added to make them clickable.

Tests: the assertion on `did not invent` no longer had a referent and now pins the new phrasing, plus a new test holding `André Berge` and the real album title so the folklore can't creep back. `deno fmt`, `deno check`, 4/4 tests pass on top of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtvQcTWPrYheznsPgvFqKR